### PR TITLE
add validation for nans in y and number of classes > 10

### DIFF
--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 from tabpfn_client.config import init
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+from sklearn.utils import column_or_1d
+from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted
 
 from tabpfn_client.config import Config
@@ -16,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 MAX_ROWS = 10000
 MAX_COLS = 500
+MAX_NUMBER_OF_CLASSES = 10
 
 
 class TabPFNModelSelection:
@@ -196,15 +199,22 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
         return res
 
     def _validate_targets_and_classes(self, y) -> np.ndarray:
-        from sklearn.utils import column_or_1d
-        from sklearn.utils.multiclass import check_classification_targets
-
         y_ = column_or_1d(y, warn=True)
+        if sum(pd.isnull(y_)) > 0:
+            raise ValueError("Input y contains NaN.")
         check_classification_targets(y)
         # Get classes and encode before type conversion to guarantee correct class labels.
-        not_nan_mask = ~pd.isnull(y)
         # TODO: should pass this from the server
-        self.classes_ = np.unique(y_[not_nan_mask])
+        self.classes_ = np.unique(y_)
+        # TODO: these things should ideally be shared with the local package
+        if len(self.classes_) > MAX_NUMBER_OF_CLASSES:
+            raise ValueError(
+                f"Number of classes {len(self.classes_)} exceeds the maximal number of "
+                f"{MAX_NUMBER_OF_CLASSES} classes supported by TabPFN. Consider using "
+                "a strategy to reduce the number of classes. For code see "
+                "https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/"
+                "tabpfn_extensions/many_class/many_class_classifier.py"
+            )
 
 
 class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
@@ -285,6 +295,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
         init()
 
         validate_data_size(X, y)
+        self._validate_targets(y)
         X = _clean_text_features(X)
         _check_paper_version(self.paper_version, X)
 
@@ -360,6 +371,11 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
             X_train=self.last_train_X,
             y_train=self.last_train_y,
         )
+
+    def _validate_targets(self, y) -> np.ndarray:
+        y_ = column_or_1d(y, warn=True)
+        if sum(pd.isnull(y_)) > 0:
+            raise ValueError("Input y contains NaN.")
 
 
 def validate_data_size(X: np.ndarray, y: Union[np.ndarray, None] = None):

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -584,6 +584,31 @@ class TestTabPFNRegressorInference(unittest.TestCase):
             # Verify predict was called twice
             self.assertEqual(mock_predict.call_count, 2)
 
+    def test_missing_values_in_y_raise_error(self):
+        """Test that missing values in y raise a ValueError."""
+        import pandas as pd
+
+        X = np.random.rand(10, 5)
+
+        # Test with None values
+        y_none = np.array([1.0, 2.0, None, 3.0, 4.0, 5.0, None, 6.0, 7.0, 8.0])
+        tabpfn = TabPFNRegressor()
+        with self.assertRaises(ValueError) as cm:
+            tabpfn.fit(X, y_none)
+        self.assertIn("contains NaN.", str(cm.exception))
+
+        # Test with np.nan values
+        y_nan = np.array([1.0, 2.0, np.nan, 3.0, 4.0, 5.0, np.nan, 6.0, 7.0, 8.0])
+        with self.assertRaises(ValueError) as cm:
+            tabpfn.fit(X, y_nan)
+        self.assertIn("contains NaN.", str(cm.exception))
+
+        # Test with pd.NA values
+        y_pd_na = pd.Series([1.0, 2.0, pd.NA, 3.0, 4.0, 5.0, pd.NA, 6.0, 7.0, 8.0])
+        with self.assertRaises(ValueError) as cm:
+            tabpfn.fit(X, y_pd_na)
+        self.assertIn("contains NaN.", str(cm.exception))
+
 
 class TestTabPFNModelSelection(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### Change Description

Add validation for nans in y, and for number of classes > 10 for classification. This is already checked in the TabPFN local package, but right now be don't pass the error back to the client so the user doesn't see it + it's quite wasteful to send a request when this would fail anyway. In the future it would be good to share more of these function between the client and the local package but I think this is fine for now.
Contrary to the local package we use `pd.isnull` instead of `check_array(force_finite=True)` because the latter outputs a warning and behave less well with `pd.NA` or None values.

**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
