### PR TITLE
replace cityhash with hashlib md5 and upgrade max python to 3.13

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,10 +34,10 @@ jobs:
             python-version: "3.9"
             dependency-set: minimum
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             dependency-set: maximum
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.13"
             dependency-set: maximum
     runs-on: ${{ matrix.os }}
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tabpfn-client"
 version = "0.1.6"
-requires-python = ">=3.9,<=3.12"
-# doesn't work with 3.12 and 3.13 because cityhash wheels are not available yet
-# (see https://github.com/escherba/python-cityhash/issues/88)
-# (can be bypassed by installing with conda)
+requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 
 description = "API access for TabPFN: Foundation model for tabular data"
@@ -27,6 +24,7 @@ classifiers = [
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
 ]
 license = { file = "LICENSE" }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ httpx>=0.25.0,<=0.28.1
 omegaconf>=2.1.2,<=2.3.0
 pandas>=2.1.2,<=2.2.3
 password-strength>=0.0.3.post2,<=0.0.3.post2
-cityhash>=0.4.3,<=0.4.7
 sseclient-py>=1.8.0,<=1.8.0
 tqdm>=4.63.0,<=4.67.1

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -13,7 +13,7 @@ import numpy as np
 from omegaconf import OmegaConf
 import json
 from typing import Literal, Optional, Union
-from cityhash import CityHash128
+import hashlib
 import os
 from collections import OrderedDict
 import sseclient
@@ -77,7 +77,7 @@ class DatasetUIDCacheManager:
         combined_bytes = b"".join(
             item if isinstance(item, bytes) else str.encode(item) for item in args
         )
-        return str(CityHash128(combined_bytes))
+        return hashlib.md5(combined_bytes).hexdigest()
 
     def get_dataset_uid(self, *args):
         """

--- a/tabpfn_client/tests/quick_test.py
+++ b/tabpfn_client/tests/quick_test.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 from sklearn.datasets import load_breast_cancer, load_diabetes
 from sklearn.model_selection import train_test_split
 
-from tabpfn_client import UserDataClient
+# from tabpfn_client import UserDataClient
 from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
 
 logging.basicConfig(level=logging.DEBUG)
@@ -37,7 +37,8 @@ if __name__ == "__main__":
         print("predicting_proba")
         print(tabpfn.predict_proba(X_test))
 
-        print(UserDataClient.get_data_summary())
+        # can be slow if you have a lot of data
+        # print(UserDataClient.get_data_summary())
 
         X, y = load_diabetes(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(
@@ -50,7 +51,7 @@ if __name__ == "__main__":
         print("predicting reg")
         print(tabpfn.predict(X_test, output_type="mean"))
 
-        print(UserDataClient.get_data_summary())
+        # print(UserDataClient.get_data_summary())
         # test predict_full
         print("predicting ")
         print(


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*
`python-cityhash` is the only thing preventing us to moving to python3.12 and python3.13 (see https://github.com/escherba/python-cityhash/issues/88). This PR replace this with native hashlib md5 and upgrade max python to 3.13 (and remove max python version all-together, see discussion [here](https://github.com/PriorLabs/TabPFN/issues/234) for the local package).

**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
