### PR TITLE
feat: adds caching for github pr workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Report cache status
         run: |
-          echo "Cache status: ${{ steps.pip-cache.outputs.cache-hit == 'true' ? 'HIT' : 'MISS' }}"
+          echo "Cache status: ${{ steps.pip-cache.outputs.cache-hit == 'true' && 'HIT' || 'MISS'}}"
           echo "Installation time: ${{ steps.install-deps.outputs.duration }} ms"
 
       - name: Run Tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Report cache status
         run: |
-          echo "Cache status: ${{ steps.pip-cache.outputs.cache-hit == 'true' && 'HIT' || 'MISS'}}"
+          echo "Cache status: ${{ steps.pip-cache.outputs.cache-hit == 'true' ? 'HIT' : 'MISS' }}"
           echo "Installation time: ${{ steps.install-deps.outputs.duration }} ms"
 
       - name: Run Tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           src: "./"
           version: 0.3.3
-          args: 'format --check'
+          args: "format --check"
 
   test_compatibility:
     name: Test Package Compatibility
@@ -30,7 +30,7 @@ jobs:
             python-version: "3.9"
             dependency-set: minimum
           - os: macos-13 # macos-latest doesn't work with python 3.10
-          # https://github.com/actions/setup-python/issues/855
+            # https://github.com/actions/setup-python/issues/855
             python-version: "3.9"
             dependency-set: minimum
           - os: ubuntu-latest
@@ -40,10 +40,10 @@ jobs:
             python-version: "3.13"
             dependency-set: maximum
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -58,10 +58,10 @@ jobs:
         run: |
           python << EOF
           import re
-          
+
           with open('requirements.txt', 'r') as f:
               reqs = f.readlines()
-          
+
           min_reqs = []
           for req in reqs:
               req = req.strip()
@@ -72,8 +72,8 @@ jobs:
               if match:
                   package, min_ver, _ = match.groups()
                   min_reqs.append(f"{package}=={min_ver}")
-          
-          with open('requirements.txt', 'w') as f:
+
+          with open('requirements-generated.txt', 'w') as f:
               f.write('\n'.join(min_reqs))
           EOF
 
@@ -82,10 +82,10 @@ jobs:
         run: |
           python << EOF
           import re
-          
+
           with open('requirements.txt', 'r') as f:
               reqs = f.readlines()
-          
+
           max_reqs = []
           for req in reqs:
               req = req.strip()
@@ -96,19 +96,44 @@ jobs:
               if match:
                   package, _, max_ver = match.groups()
                   max_reqs.append(f"{package}=={max_ver}")
-          
-          with open('requirements.txt', 'w') as f:
+
+          with open('requirements-generated.txt', 'w') as f:
               f.write('\n'.join(max_reqs))
           EOF
 
+      # Caching based on dependency set and python version. It needs to be done post any operations that modifies the file (like `write`, `touch`, etc.) that can change the hash of the dependency file and lead to a cache miss.
+      # REFER: https://github.com/actions/setup-python#caching-packages-dependencies
+      - name: Setup pip cache
+        id: pip-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.dependency-set }}-${{ hashFiles('requirements-test.txt', 'requirements-generated.txt')}}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.dependency-set }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
       - name: Install dependencies
+        id: install-deps
         run: |
+          echo "::group::Installing dependencies"
+          START_TIME=$(date +%s%N)
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
-          pip install -r requirements.txt
+          pip install -r requirements-generated.txt
+          END_TIME=$(date +%s%N)
+          DURATION=$((($END_TIME - $START_TIME)/1000000))
+          echo "duration=$DURATION" >> $GITHUB_OUTPUT
+          echo "Dependencies installation took $DURATION ms"
+          echo "::endgroup::"
 
       - name: Initialize submodules
         run: git submodule update --init --recursive
+
+      - name: Report cache status
+        run: |
+          echo "Cache status: ${{ steps.pip-cache.outputs.cache-hit == 'true' && 'HIT' || 'MISS'}}"
+          echo "Installation time: ${{ steps.install-deps.outputs.duration }} ms"
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
### Change Description

Resolves : https://github.com/PriorLabs/tabpfn-client/issues/96

This change adds manual cache management using actions/cache. This is preffered over automatic cache management in  `actions/setup-python` because the cache management depends on the dependency file. In our case, its the requirements.txt and requirements-test.txt file. 

We are modifying those files post `Setup Python` rule. This changes the hash of the file thus leading to cache miss. The manual management should overcome that since we are cacluating the cache post any change to dependency file.


**If you used new dependencies: Did you add them to `requirements.txt`?** NO.

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?** NO

**Does this PR break the user interface? If so, why?** NO

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
