### PR TITLE
Add usage analytics tracking

### DIFF
--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -25,6 +25,7 @@ from tabpfn_client.tabpfn_common_utils import utils as common_utils
 from tabpfn_client.constants import CACHE_DIR
 from tabpfn_client.browser_auth import BrowserAuthHandler
 from tabpfn_client.tabpfn_common_utils.utils import Singleton
+from tabpfn_client.tabpfn_common_utils.usage_analytics import AnalyticsHttpClient
 
 logger = logging.getLogger(__name__)
 
@@ -157,10 +158,11 @@ class ServiceClient(Singleton):
     httpx_timeout_s = (
         4 * 5 * 60 + 15  # temporary workaround for slow computation on server side
     )
-    httpx_client = httpx.Client(
+    httpx_client = AnalyticsHttpClient(
         base_url=base_url,
         timeout=httpx_timeout_s,
         headers={"client-version": get_client_version()},
+        module_name="tabpfn_client",
     )
 
     _access_token = None

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -169,6 +169,10 @@ class ServiceClient(Singleton):
     dataset_uid_cache_manager = DatasetUIDCacheManager()
 
     @classmethod
+    def set_module_name(cls, module_name: str):
+        cls.httpx_client.module_name = module_name
+
+    @classmethod
     def get_access_token(cls):
         return cls._access_token
 

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -21,7 +21,10 @@ class Config:
     use_server = False
 
 
-def init(use_server=True):
+def init(
+    use_server=True,
+    module_name="tabpfn_client",
+):
     # initialize config
     Config.use_server = use_server
 
@@ -30,6 +33,8 @@ def init(use_server=True):
         return
 
     if use_server:
+        ServiceClient.set_module_name(module_name)
+
         # check connection to server
         if not UserAuthenticationClient.is_accessible_connection():
             raise RuntimeError(


### PR DESCRIPTION
### Change Description

**Add minimal usage analytics tracking**:
- `tabpfn_client` extracts basic usage info based on the caller's environment, and sends this info in request headers.
- tracking non-privacy intrusive metadata, see "tabpfn_common_utils/usage_analytics/analytics_definition.py"
  ``` python
  ANALYTICS_TO_TRACK = [
    ("X-Unique-Call-Id", get_unique_call_id),
    ("X-Python-Version", get_python_version),
    ("X-Calling-Class", get_calling_class),
    ("X-Module-Name", None),  # Value provided by AnalyticsHttpClient 
  ]
  ``` 

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*


**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
