### PR TITLE
Minor fixes for 0.1.9 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,6 @@ pip install -e ".[dev]"
 
 ```bash
 if [ -d "dist" ]; then rm -rf dist/*; fi
-python3 -m pip install --upgrade build; python3 -m build
-python3 -m twine upload --repository pypi dist/*
+python3 -m pip install --upgrade build && python3 -m build
+python3 -m pip install --upgrade twine && python3 -m twine upload --repository pypi dist/*
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.1.9"
+version = "0.1.8"
 requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "1.8.1"
+version = "0.1.9"
 requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.1.7"
+version = "1.8.1"
 requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.1.8"
+version = "0.1.9"
 requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@
 pre-commit==4.2.0
 pytest==8.4.1
 ruff==0.11.9
-twine==6.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 
 # lint and format checking
 pre-commit==4.2.0
-pytest
-ruff == 0.11.9
-twine
+pytest==8.4.1
+ruff==0.11.9
+twine==6.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 ### additional requirements for development
 
 # lint and format checking
-pytest
 pre-commit==4.2.0
+pytest
 ruff == 0.11.9
-typing_extensions==4.12.2
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ password-strength>=0.0.3.post2,<=0.0.3.post2
 scikit-learn>=1.3.1,<=1.6.1
 sseclient-py>=1.8.0,<=1.8.0
 tqdm>=4.63.0,<=4.67.1
-typing_extensions==4.12.2
+typing_extensions>=4.12.2,<=typing-extensions 4.14.1
 xxhash>=1.1.0,<=3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ password-strength>=0.0.3.post2,<=0.0.3.post2
 scikit-learn>=1.3.1,<=1.6.1
 sseclient-py>=1.8.0,<=1.8.0
 tqdm>=4.63.0,<=4.67.1
-typing_extensions>=4.12.2,<=typing-extensions 4.14.1
+typing_extensions>=4.12.2,<=4.14.1
 xxhash>=1.1.0,<=3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 # TODO(fjablonski): Convert this requirements to pyproject.toml with uv
-scikit-learn>=1.3.1,<=1.6.1
 httpx>=0.25.0,<=0.28.1
 omegaconf>=2.1.2,<=2.3.0
 pandas>=2.1.2,<=2.3.1
 password-strength>=0.0.3.post2,<=0.0.3.post2
+scikit-learn>=1.3.1,<=1.6.1
 sseclient-py>=1.8.0,<=1.8.0
 tqdm>=4.63.0,<=4.67.1
+typing_extensions==4.12.2
 xxhash>=1.1.0,<=3.5


### PR DESCRIPTION
- Bump version
- Add twine to README.md for release process
- Move typing_extensions from dev to main `requirements.txt`. This seems necessary. Otherwise we have failures running `quick_test.py` which is really just a simple demo of the package.