### PR TITLE
Check token before writing in set_token

### DIFF
--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -43,10 +43,11 @@ class UserAuthenticationClient(ServiceClientWrapper, Singleton):
 
         # Mitigate parallel writes by checking if the token is already set to
         # the same value. We'll consider using fcntl if this problem persists.
-        if cls.CACHED_TOKEN_FILE.exists():
-            current_token = cls.CACHED_TOKEN_FILE.read_text()
-            if current_token == access_token:
+        try:
+            if cls.CACHED_TOKEN_FILE.read_text() == access_token:
                 return
+        except FileNotFoundError:
+            pass
 
         # Write the new token
         cls.CACHED_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -40,6 +40,15 @@ class UserAuthenticationClient(ServiceClientWrapper, Singleton):
     @classmethod
     def set_token(cls, access_token: str):
         ServiceClient.authorize(access_token)
+
+        # Mitigate parallel writes by checking if the token is already set to
+        # the same value. We'll consider using fcntl if this problem persists.
+        if cls.CACHED_TOKEN_FILE.exists():
+            current_token = cls.CACHED_TOKEN_FILE.read_text()
+            if current_token == access_token:
+                return
+
+        # Write the new token
         cls.CACHED_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
         cls.CACHED_TOKEN_FILE.write_text(access_token)
 


### PR DESCRIPTION
In certain cases users may want to use tabpfn-client in parallel. Previously we were always writing to disk when `set_token` was called, not to mention calling it somewhat aggressively. This change mitigates the race condition in those cases.