### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.1.9"
+version = "0.1.10"
 requires-python = ">=3.9"
 dynamic = ["dependencies", "optional-dependencies"]
 


### PR DESCRIPTION
To match what's on PyPI: https://pypi.org/project/tabpfn-client/0.1.10/