### PR TITLE
Fix client error in regression

### DIFF
--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -10,7 +10,7 @@ Prediction = Union[
     List[PredictionScalar],
     List[float],
     List[List[float]],
-    Dict[str, Union[List[float], List[List[float]]]],
+    Dict[str, Union[List[Optional[float]], List[List[Optional[float]]]]],
 ]
 
 TabPFNConfig = Optional[Dict[str, Any]]


### PR DESCRIPTION
For some reason we are (and apparently were?) getting `None` in the logits from regression with full output. Not clear to me why this would happen, but since it's a standing issue, seem worth just loosening the type