### PR TITLE
Adjust interfaces pre-release

### DIFF
--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -274,8 +274,8 @@ class ServiceClient(Singleton):
         task: Literal["classification", "regression"],
         tabpfn_config: Union[dict, None] = None,
         description: str | None = None,
+        force_refit: bool = False,
         client_options: ClientOptions | None = None,
-        is_refitting: bool = False,
     ) -> UUID:
         """
         Upload a train set to server and return the train set UID if successful.
@@ -293,6 +293,8 @@ class ServiceClient(Singleton):
             `paper_version`.
         description: str, optional
             Description of the dataset and task for the server.
+        force_refit: bool, optional
+            Whether to force refit the model even if the model has already been fitted.
         client_options : ClientOptions, optional
             Per-request options (e.g. timeout, headers) for the fitting API call
             only. Does not apply to file uploads. Because uploads can run before fitting,
@@ -432,7 +434,7 @@ class ServiceClient(Singleton):
                 train_set_upload_id=prepare_resp.train_set_upload_id,
                 task=task,
                 tabpfn_systems=tabpfn_systems,
-                force_refit=is_refitting or force_refit_enabled(),
+                force_refit=force_refit or force_refit_enabled(),
                 tabpfn_config=server_tabpfn_config,
                 enhanced_fit_mode_metric=enhanced_fit_mode_metric,
                 enhanced_fit_time_limit_s=enhanced_fit_time_limit_s,

--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -296,9 +296,7 @@ class ServiceClient(Singleton):
         force_refit: bool, optional
             Whether to force refit the model even if the model has already been fitted.
         client_options : ClientOptions, optional
-            Per-request options (e.g. timeout, headers) for the fitting API call
-            only. Does not apply to file uploads. Because uploads can run before fitting,
-            this method may return later than the timeout specified.
+            Client specific options (e.g. timeout, headers).
 
         Returns
         -------
@@ -509,9 +507,7 @@ class ServiceClient(Singleton):
         predict_params: dict, optional
             Parameters for the predict method.
         client_options : ClientOptions, optional
-            Per-request options (e.g. timeout, headers) for the fitting API call
-            only. Does not apply to file uploads. Because uploads can run before fitting,
-            this method may return later than the timeout specified.
+            Client specific options (e.g. timeout, headers).
 
         Returns
         -------

--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -216,11 +216,12 @@ class ServiceClient(Singleton):
         or f"{server_config.protocol}://{server_config.host}:{server_config.port}"
     )
     fit_path = SERVER_CONFIG["endpoints"]["fit"]["path"]
+    predict_path = SERVER_CONFIG["endpoints"]["predict"]["path"]
     httpx_client = httpx.Client(
         base_url=base_url,
         timeout=TABPFN_CLIENT_TIMEOUT,
         headers={"Prior-Client-Version": get_client_version()},
-        transport=SelectiveHTTP2Transport(http2_paths=[fit_path]),
+        transport=SelectiveHTTP2Transport(http2_paths=[fit_path, predict_path]),
         follow_redirects=True,
     )
     _access_token = None

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -513,9 +513,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         force_refit: bool, default=False
             Whether to force refit the model even if the model has already been fitted.
         client_options : ClientOptions, default=None
-            Per-request options (e.g. timeout, headers) for the fitting API call
-            only. Does not apply to file uploads. Because uploads can run before fitting,
-            this method may return later than the timeout specified.
+            Client specific options (e.g. timeout, headers).
         """
         self.model_path = model_path
         self.n_estimators = n_estimators

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -128,6 +128,9 @@ class TabPFNModelSelection:
         """
         estimator_param = self.get_params()
         estimator_param["model_path"] = self._model_name_to_path(task, self.model_path)
+        # Client-side concerns — passed separately to InferenceClient, not part of server config.
+        estimator_param.pop("client_options", None)
+        estimator_param.pop("force_refit", None)
         return estimator_param
 
 

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -291,6 +291,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                     task="classification",
                     tabpfn_config=estimator_param,
                     description=description,
+                    force_refit=self.force_refit,
                     client_options=self.client_options,
                 )
 
@@ -365,8 +366,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                         task="classification",
                         tabpfn_config=estimator_param,
                         description=self.last_train_set_description,
+                        force_refit=True,
                         client_options=self.client_options,
-                        is_refitting=True,
                     )
 
         result = run_task(predict_task, "Predicting")
@@ -496,6 +497,12 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             the default ~5-minute sweep leaves performance on the table.
             None falls back to the server-side default (300s). Capped at
             2400 seconds (40 minutes); higher values raise ValueError at fit.
+        force_refit: bool, default=False
+            Whether to force refit the model even if the model has already been fitted.
+        client_options : ClientOptions, default=None
+            Per-request options (e.g. timeout, headers) for the fitting API call
+            only. Does not apply to file uploads. Because uploads can run before fitting,
+            this method may return later than the timeout specified.
         """
         self.model_path = model_path
         self.n_estimators = n_estimators
@@ -548,6 +555,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                     task="regression",
                     tabpfn_config=estimator_param,
                     description=description,
+                    force_refit=self.force_refit,
                     client_options=self.client_options,
                 )
 
@@ -633,8 +641,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                         task="regression",
                         tabpfn_config=estimator_param,
                         description=self.last_train_set_description,
+                        force_refit=True,
                         client_options=self.client_options,
-                        is_refitting=True,
                     )
 
         result = run_task(predict_task, "Predicting")

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -169,6 +169,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         enhanced_fit_mode: bool = False,
         enhanced_fit_mode_metric: Optional[str] = None,
         enhanced_fit_mode_time_limit_s: Optional[float] = None,
+        force_refit: bool = False,
+        client_options: ClientOptions | None = None,
     ):
         """Construct a TabPFN classifier.
 
@@ -250,6 +252,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.enhanced_fit_mode = enhanced_fit_mode
         self.enhanced_fit_mode_metric = enhanced_fit_mode_metric
         self.enhanced_fit_mode_time_limit_s = enhanced_fit_mode_time_limit_s
+        self.force_refit = force_refit
+        self.client_options = client_options or ClientOptions()
+
         self.last_trace_id = None
         self.last_fitted_train_set_id = None
         self.last_train_X = None
@@ -262,7 +267,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         X: pd.DataFrame | np.ndarray,
         y: pd.Series | np.ndarray,
         description: str | None = None,
-        client_options: ClientOptions | None = None,
     ):
         # assert init() is called
         init()
@@ -274,11 +278,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self._validate_targets_and_classes(y)
 
         if Config.use_server:
-            client_options = client_options or ClientOptions()
-            if "sentry-trace" not in client_options.headers:
-                client_options.headers["sentry-trace"] = uuid4().hex
+            if "sentry-trace" not in self.client_options.headers:
+                self.client_options.headers["sentry-trace"] = uuid4().hex
 
-            self.last_trace_id = client_options.headers["sentry-trace"]
+            self.last_trace_id = self.client_options.headers["sentry-trace"]
             self.last_train_set_description = description
 
             def fit_task() -> UUID:
@@ -288,7 +291,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                     task="classification",
                     tabpfn_config=estimator_param,
                     description=description,
-                    client_options=client_options,
+                    client_options=self.client_options,
                 )
 
             self.last_fitted_train_set_id = run_task(fit_task, "Fitting")
@@ -301,11 +304,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             )
         return self
 
-    def predict(
-        self,
-        X,
-        client_options: ClientOptions | None = None,
-    ):
+    def predict(self, X):
         """Predict class labels for samples in X.
 
         Args:
@@ -314,17 +313,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         Returns:
             The predicted class labels.
         """
-        return self._predict(
-            X,
-            output_type="preds",
-            client_options=client_options,
-        )
+        return self._predict(X, output_type="preds")
 
-    def predict_proba(
-        self,
-        X,
-        client_options: ClientOptions | None = None,
-    ):
+    def predict_proba(self, X):
         """Predict class probabilities for X.
 
         Args:
@@ -333,26 +324,20 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         Returns:
             The class probabilities of the input samples.
         """
-        return self._predict(
-            X,
-            output_type="probas",
-            client_options=client_options,
-        )
+        return self._predict(X, output_type="probas")
 
     def _predict(
         self,
         X,
         output_type,
-        client_options: ClientOptions | None = None,
     ) -> dict[str, np.ndarray]:
         check_is_fitted(self)
         estimator_param = self._get_estimator_params_with_model_path("classification")
         validate_test_set(X, output_type, estimator_param["model_path"])
         X = _clean_text_features(X)
 
-        client_options = client_options or ClientOptions()
-        if "sentry-trace" not in client_options.headers:
-            client_options.headers["sentry-trace"] = self.last_trace_id
+        if "sentry-trace" not in self.client_options.headers:
+            self.client_options.headers["sentry-trace"] = self.last_trace_id
 
         def predict_task() -> PredictionResult:
             last_exc = None
@@ -369,7 +354,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                         task="classification",
                         tabpfn_config=estimator_param,
                         predict_params={"output_type": output_type},
-                        client_options=client_options,
+                        client_options=self.client_options,
                     )
                 except NeedsRefittingError as exc:
                     last_exc = exc
@@ -380,7 +365,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                         task="classification",
                         tabpfn_config=estimator_param,
                         description=self.last_train_set_description,
-                        client_options=client_options,
+                        client_options=self.client_options,
                         is_refitting=True,
                     )
 
@@ -451,6 +436,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         enhanced_fit_mode: bool = False,
         enhanced_fit_mode_metric: Optional[str] = None,
         enhanced_fit_mode_time_limit_s: Optional[float] = None,
+        force_refit: bool = False,
+        client_options: ClientOptions | None = None,
     ):
         """Construct a TabPFN regressor.
 
@@ -522,6 +509,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.enhanced_fit_mode = enhanced_fit_mode
         self.enhanced_fit_mode_metric = enhanced_fit_mode_metric
         self.enhanced_fit_mode_time_limit_s = enhanced_fit_mode_time_limit_s
+        self.force_refit = force_refit
+        self.client_options = client_options or ClientOptions()
+
         self.last_trace_id = None
         self.last_fitted_train_set_id = None
         self.last_train_X = None
@@ -534,7 +524,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         X: pd.DataFrame | np.ndarray,
         y: pd.Series | np.ndarray,
         description: str | None = None,
-        client_options: ClientOptions | None = None,
     ):
         # assert init() is called
         init()
@@ -546,11 +535,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         X = _clean_text_features(X)
 
         if Config.use_server:
-            client_options = client_options or ClientOptions()
-            if "sentry-trace" not in client_options.headers:
-                client_options.headers["sentry-trace"] = uuid4().hex
+            if "sentry-trace" not in self.client_options.headers:
+                self.client_options.headers["sentry-trace"] = uuid4().hex
 
-            self.last_trace_id = client_options.headers["sentry-trace"]
+            self.last_trace_id = self.client_options.headers["sentry-trace"]
             self.last_train_set_description = description
 
             def fit_task() -> UUID:
@@ -560,7 +548,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                     task="regression",
                     tabpfn_config=estimator_param,
                     description=description,
-                    client_options=client_options,
+                    client_options=self.client_options,
                 )
 
             self.last_fitted_train_set_id = run_task(fit_task, "Fitting")
@@ -581,7 +569,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             "mean", "median", "mode", "quantiles", "full", "main"
         ] = "mean",
         quantiles: Optional[list[float]] = None,
-        client_options: ClientOptions | None = None,
     ) -> Union[np.ndarray, list[np.ndarray], dict[str, np.ndarray]]:
         """Predict regression target for X.
 
@@ -617,9 +604,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             "quantiles": quantiles,
         }
 
-        client_options = client_options or ClientOptions()
-        if "sentry-trace" not in client_options.headers:
-            client_options.headers["sentry-trace"] = self.last_trace_id
+        if "sentry-trace" not in self.client_options.headers:
+            self.client_options.headers["sentry-trace"] = self.last_trace_id
 
         def predict_task() -> PredictionResult:
             last_exc = None
@@ -636,7 +622,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                         task="regression",
                         tabpfn_config=estimator_param,
                         predict_params=predict_params,
-                        client_options=client_options,
+                        client_options=self.client_options,
                     )
                 except NeedsRefittingError as exc:
                     last_exc = exc
@@ -647,7 +633,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                         task="regression",
                         tabpfn_config=estimator_param,
                         description=self.last_train_set_description,
-                        client_options=client_options,
+                        client_options=self.client_options,
                         is_refitting=True,
                     )
 

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -261,6 +261,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.last_train_y = None
         self.last_meta = {}
         self.last_train_set_description = None
+        self.fit_count = 0
 
     def fit(
         self,
@@ -278,7 +279,15 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self._validate_targets_and_classes(y)
 
         if Config.use_server:
-            if "sentry-trace" not in self.client_options.headers:
+            # Create a new sentry trace at every fit, provided that:
+            # - The user has not explicitly set a sentry-trace header.
+            # - In any case if we're going to refit.
+            # - In any case if we have already called .fit() on this instance.
+            if (
+                self.force_refit
+                or self.fit_count > 0
+                or "sentry-trace" not in self.client_options.headers
+            ):
                 self.client_options.headers["sentry-trace"] = uuid4().hex
 
             self.last_trace_id = self.client_options.headers["sentry-trace"]
@@ -299,6 +308,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True
+            self.fit_count += 1
         else:
             raise NotImplementedError(
                 "Only server mode is supported at the moment for init(use_server=False)"
@@ -525,6 +535,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.last_train_y = None
         self.last_meta = {}
         self.last_train_set_description = None
+        self.fit_count = 0
 
     def fit(
         self,
@@ -542,10 +553,19 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         X = _clean_text_features(X)
 
         if Config.use_server:
-            if "sentry-trace" not in self.client_options.headers:
+            # Create a new sentry trace at every fit, provided that:
+            # - The user has not explicitly set a sentry-trace header.
+            # - In any case if we're going to refit.
+            # - In any case if we have already called .fit() on this instance.
+            if (
+                self.force_refit
+                or self.fit_count > 0
+                or "sentry-trace" not in self.client_options.headers
+            ):
                 self.client_options.headers["sentry-trace"] = uuid4().hex
 
             self.last_trace_id = self.client_options.headers["sentry-trace"]
+
             self.last_train_set_description = description
 
             def fit_task() -> UUID:
@@ -563,6 +583,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True
+            self.fit_count += 1
         else:
             raise NotImplementedError(
                 "Only server mode is supported at the moment for init(use_server=False)"

--- a/src/tabpfn_client/service_wrapper.py
+++ b/src/tabpfn_client/service_wrapper.py
@@ -261,8 +261,8 @@ class InferenceClient(ServiceClientWrapper, Singleton):
         task: Literal["classification", "regression"],
         tabpfn_config=None,
         description: str | None = None,
+        force_refit: bool = False,
         client_options: ClientOptions | None = None,
-        is_refitting: bool = False,
     ) -> UUID:
         return ServiceClient.fit(
             X,
@@ -270,8 +270,8 @@ class InferenceClient(ServiceClientWrapper, Singleton):
             task=task,
             tabpfn_config=tabpfn_config,
             description=description,
+            force_refit=force_refit,
             client_options=client_options,
-            is_refitting=is_refitting,
         )
 
     @classmethod


### PR DESCRIPTION
- [x] http2 on `/tabpfn/predict` for forward compatibility.
- [x] move client_options to the estimator interface.
- [x] add `force_refit` as an option to the estimator interface.
- [x] adjust way we create a sentry-trace as headers are set on the estimator now instead of the method.