### PR TITLE
Require typed-phrase for user account deletion in client

### DIFF
--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -1267,10 +1267,9 @@ class ServiceClient(Singleton):
         return response.json()["deleted_dataset_uids"]
 
     @classmethod
-    def delete_user_account(cls, confirm_pass: str) -> None:
+    def delete_user_account(cls) -> None:
         response = cls.httpx_client.delete(
             cls.server_endpoints.delete_user_account.path,
-            params={"confirm_password": confirm_pass},
         )
 
         cls._validate_response(response, "delete_user_account")

--- a/src/tabpfn_client/prompt_agent.py
+++ b/src/tabpfn_client/prompt_agent.py
@@ -587,12 +587,18 @@ class PromptAgent:
         for message in greeting_messages:
             cls._print(message)
 
-    @classmethod
-    def prompt_confirm_password_for_user_account_deletion(cls) -> str:
-        warn("You are about to delete your account.")
-        confirm_pass = getpass.getpass("Please confirm by entering your password: ")
+    CONFIRM_DELETION_PHRASE = "confirm deletion"
 
-        return confirm_pass
+    @classmethod
+    def confirm_user_account_deletion(cls) -> bool:
+        warn(
+            "You are about to delete your account. This is permanent and "
+            "cannot be undone."
+        )
+        typed = console.input(
+            f"Type '{cls.CONFIRM_DELETION_PHRASE}' to proceed (anything else cancels): "
+        )
+        return typed.strip().lower() == cls.CONFIRM_DELETION_PHRASE
 
     @classmethod
     def prompt_account_deleted(cls):

--- a/src/tabpfn_client/prompt_agent.py
+++ b/src/tabpfn_client/prompt_agent.py
@@ -598,7 +598,7 @@ class PromptAgent:
         typed = console.input(
             f"Type '{cls.CONFIRM_DELETION_PHRASE}' to proceed (anything else cancels): "
         )
-        return typed.strip().lower() == cls.CONFIRM_DELETION_PHRASE
+        return typed.strip().lower() == cls.CONFIRM_DELETION_PHRASE.lower()
 
     @classmethod
     def prompt_account_deleted(cls):

--- a/src/tabpfn_client/service_wrapper.py
+++ b/src/tabpfn_client/service_wrapper.py
@@ -231,9 +231,12 @@ class UserDataClient(ServiceClientWrapper, Singleton):
         # local import to avoid circular import
         from tabpfn_client.prompt_agent import PromptAgent
 
-        confirm_pass = PromptAgent.prompt_confirm_password_for_user_account_deletion()
+        if not PromptAgent.confirm_user_account_deletion():
+            logging.info("Account deletion cancelled — confirmation phrase not entered.")
+            return
+
         try:
-            ServiceClient.delete_user_account(confirm_pass)
+            ServiceClient.delete_user_account()
         except RuntimeError as e:
             logging.error(f"Failed to delete user account: {e}")
             raise e

--- a/src/tabpfn_client/service_wrapper.py
+++ b/src/tabpfn_client/service_wrapper.py
@@ -232,7 +232,7 @@ class UserDataClient(ServiceClientWrapper, Singleton):
         from tabpfn_client.prompt_agent import PromptAgent
 
         if not PromptAgent.confirm_user_account_deletion():
-            logging.info("Account deletion cancelled — confirmation phrase not entered.")
+            logger.info("Account deletion cancelled — confirmation phrase not entered.")
             return
 
         try:

--- a/tests/unit/test_service_wrapper.py
+++ b/tests/unit/test_service_wrapper.py
@@ -259,37 +259,44 @@ class TestUserDataClient(unittest.TestCase):
         self.assertEqual(["dummy_uid"], UserDataClient.delete_all_datasets())
 
     @with_mock_server()
-    @patch(
-        "tabpfn_client.prompt_agent.PromptAgent.prompt_confirm_password_for_user_account_deletion"
-    )
-    def test_delete_user_account_with_valid_password(
-        self, mock_server, mock_prompt_confirm_password
+    @patch("tabpfn_client.prompt_agent.PromptAgent.confirm_user_account_deletion")
+    def test_delete_user_account_when_confirmed(
+        self, mock_server, mock_confirm_deletion
     ):
-        # mock delete_user_account response
-        mock_server.router.delete(
+        delete_route = mock_server.router.delete(
             mock_server.endpoints.delete_user_account.path
         ).respond(200)
+        mock_confirm_deletion.return_value = True
 
-        # mock password prompting
-        mock_prompt_confirm_password.return_value = "dummy_password"
-
-        # assert no exception is raised
         UserDataClient.delete_user_account()
 
+        # The wire call must NOT include confirm_password — the param is gone
+        # from the SDK as of this PR. That's the whole point of the change.
+        self.assertEqual(1, delete_route.call_count)
+        self.assertNotIn(b"confirm_password", delete_route.calls.last.request.url.query)
+
     @with_mock_server()
-    @patch(
-        "tabpfn_client.prompt_agent.PromptAgent.prompt_confirm_password_for_user_account_deletion"
-    )
-    def test_delete_user_account_with_invalid_password(
-        self, mock_server, mock_prompt_confirm_password
+    @patch("tabpfn_client.prompt_agent.PromptAgent.confirm_user_account_deletion")
+    def test_delete_user_account_when_cancelled(
+        self, mock_server, mock_confirm_deletion
     ):
-        # mock delete_user_account response
+        # Deliberately do NOT register a delete route. If the SDK calls the
+        # endpoint despite a declined confirmation, respx will raise on the
+        # unmocked request.
+        mock_confirm_deletion.return_value = False
+
+        UserDataClient.delete_user_account()
+
+        self.assertEqual(0, mock_server.router.calls.call_count)
+
+    @with_mock_server()
+    @patch("tabpfn_client.prompt_agent.PromptAgent.confirm_user_account_deletion")
+    def test_delete_user_account_propagates_server_error(
+        self, mock_server, mock_confirm_deletion
+    ):
         mock_server.router.delete(
             mock_server.endpoints.delete_user_account.path
-        ).respond(400)
+        ).respond(500)
+        mock_confirm_deletion.return_value = True
 
-        # mock password prompting
-        mock_prompt_confirm_password.return_value = "dummy_password"
-
-        # assert exception is raised
         self.assertRaises(RuntimeError, UserDataClient.delete_user_account)


### PR DESCRIPTION
* Bearer token already sufficiently authenticates the user
* Instead of confirm password; move to typed phrase deletion in client