### PR TITLE
chore: align client interface to OSS interface

### DIFF
--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -170,7 +170,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         softmax_temperature: float = 0.9,
         balance_probabilities: bool = False,
         average_before_softmax: bool = False,
-        ignore_pretraining_limits: bool = False,
+        ignore_pretraining_limits: bool = True,
         inference_precision: Literal["autocast", "auto"] = "auto",
         random_state: Optional[
             Union[int, np.random.RandomState, np.random.Generator]
@@ -217,11 +217,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
              predictive performance when there are many classes or when calibrating the
              model's confidence. This is only applied when predicting during a
              post-processing.
-        ignore_pretraining_limits: bool, default=False
+        ignore_pretraining_limits: bool, default=True
             Whether to ignore the pre-training limits of the model. The TabPFN models
             have been pre-trained on a specific range of input data. If the input data
             is outside of this range, the model may not perform well. You may ignore
             our limits to use the model on data outside the pre-training range.
+            Defaults to True (vs False in the OSS package): the server enforces its
+            own capacity limits, so the OSS check is redundant and stricter.
         inference_precision: "autocast" or "auto", default="auto"
             The precision to use for inference. This can dramatically affect the
             speed and reproducibility of the inference.

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -49,6 +49,11 @@ DEFAULT_V2_MODEL_PATH = "v2_default"
 DEFAULT_V2_5_MODEL_PATH = "v2.5_default"
 DEFAULT_V3_MODEL_PATH = "v3_default"
 
+# Sentinel values for `model_path` that defer model selection to the server.
+# "auto" is the canonical name (matches the OSS tabpfn package); "default"
+# is kept as a backward-compatible alias.
+_AUTO_MODEL_PATH_ALIASES = frozenset({"auto", "default"})
+
 ENHANCED_FIT_MODE_MAX_TIME_LIMIT_S = 40 * 60
 
 
@@ -64,7 +69,10 @@ class TabPFNModelSelection:
 
     @classmethod
     def _validate_model_name(cls, model_name: str) -> None:
-        if model_name != "default" and model_name not in cls._AVAILABLE_MODELS:
+        if (
+            model_name not in _AUTO_MODEL_PATH_ALIASES
+            and model_name not in cls._AVAILABLE_MODELS
+        ):
             raise ValueError(
                 f"Invalid model name: {model_name}. "
                 f"Available models are: {cls.list_available_models()}"
@@ -76,8 +84,8 @@ class TabPFNModelSelection:
     ) -> Optional[str]:
         cls._validate_model_name(model_name)
         model_name_task = "classifier" if task == "classification" else "regressor"
-        # Let the server handle the default model. This enables v2.5 as well.
-        if model_name == "default":
+        # Let the server pick the default model when the caller defers to us.
+        if model_name in _AUTO_MODEL_PATH_ALIASES:
             return None
         if V_3_IDENTIFIER in model_name:
             return f"tabpfn-{V_3_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
@@ -147,7 +155,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         "v2.5_real",
         "v2.5_variant",
         DEFAULT_V2_MODEL_PATH,
-        "default",
+        "auto",
         "gn2p4bpt",
         "llderlii",
         "od3j1g5m",
@@ -157,16 +165,16 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
 
     def __init__(
         self,
-        model_path: str = "default",
+        model_path: str = "auto",
         n_estimators: int = 8,
         softmax_temperature: float = 0.9,
         balance_probabilities: bool = False,
         average_before_softmax: bool = False,
-        ignore_pretraining_limits: bool = True,
+        ignore_pretraining_limits: bool = False,
         inference_precision: Literal["autocast", "auto"] = "auto",
         random_state: Optional[
             Union[int, np.random.RandomState, np.random.Generator]
-        ] = None,
+        ] = 0,
         inference_config: Optional[Dict] = None,
         paper_version: bool = False,
         enhanced_fit_mode: bool = False,
@@ -183,8 +191,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
 
         Parameters
         ----------
-        model_path: str, default="default"
-            The name of the model to use.
+        model_path: str, default="auto"
+            The name of the model to use. "auto" lets the server pick the
+            latest default model; "default" is accepted as a backward-compatible
+            alias. Use `create_default_for_version()` to pin to a specific
+            major version.
         n_estimators: int, default=8
             The number of estimators in the TabPFN ensemble. We aggregate the
              predictions of `n_estimators`-many forward passes of TabPFN. Each forward
@@ -206,7 +217,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
              predictive performance when there are many classes or when calibrating the
              model's confidence. This is only applied when predicting during a
              post-processing.
-        ignore_pretraining_limits: bool, default=True
+        ignore_pretraining_limits: bool, default=False
             Whether to ignore the pre-training limits of the model. The TabPFN models
             have been pre-trained on a specific range of input data. If the input data
             is outside of this range, the model may not perform well. You may ignore
@@ -214,8 +225,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         inference_precision: "autocast" or "auto", default="auto"
             The precision to use for inference. This can dramatically affect the
             speed and reproducibility of the inference.
-        random_state: int or RandomState or RandomGenerator or None, default=None
-            Controls the randomness of the model. Pass an int for reproducible results.
+        random_state: int or RandomState or RandomGenerator or None, default=0
+            Controls the randomness of the model. Pass an int for reproducible
+            results; pass `None` to use a fresh random seed each run.
         inference_config: dict or None, default=None
             Additional advanced arguments for model interface. See the doc of InferenceConfig
             in the tabpfn package for more details. For the client, the inference_config and the
@@ -427,7 +439,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         "v2.5_small-samples",
         "v2.5_variant",
         DEFAULT_V2_MODEL_PATH,
-        "default",
+        "auto",
         "2noar4o2",
         "5wof9ojf",
         "09gpqh39",
@@ -436,7 +448,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
 
     def __init__(
         self,
-        model_path: str = "default",
+        model_path: str = "auto",
         n_estimators: int = 8,
         softmax_temperature: float = 0.9,
         average_before_softmax: bool = False,
@@ -444,7 +456,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         inference_precision: Literal["autocast", "auto"] = "auto",
         random_state: Optional[
             Union[int, np.random.RandomState, np.random.Generator]
-        ] = None,
+        ] = 0,
         inference_config: Optional[Dict] = None,
         paper_version: bool = False,
         enhanced_fit_mode: bool = False,
@@ -461,8 +473,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
 
         Parameters
         ----------
-        model_path: str, default="default"
-            The name to the model to use.
+        model_path: str, default="auto"
+            The name of the model to use. "auto" lets the server pick the
+            latest default model; "default" is accepted as a backward-compatible
+            alias. Use `create_default_for_version()` to pin to a specific
+            major version.
         n_estimators: int, default=8
             The number of estimators in the TabPFN ensemble. We aggregate the
              predictions of `n_estimators`-many forward passes of TabPFN. Each forward
@@ -486,8 +501,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         inference_precision: "autocast" or "auto", default="auto"
             The precision to use for inference. This can dramatically affect the
             speed and reproducibility of the inference.
-        random_state: int or RandomState or RandomGenerator or None, default=None
-            Controls the randomness of the model. Pass an int for reproducible results.
+        random_state: int or RandomState or RandomGenerator or None, default=0
+            Controls the randomness of the model. Pass an int for reproducible
+            results; pass `None` to use a fresh random seed each run.
         inference_config: dict or None, default=None
             Additional advanced arguments for model interface. See the doc of InferenceConfig
             in the tabpfn package for more details. For the client, the inference_config and the

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -156,6 +156,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         "v2.5_variant",
         DEFAULT_V2_MODEL_PATH,
         "auto",
+        # Deprecated alias for "auto"; kept for backward compat with users and
+        # downstream packages (e.g. tabpfn-time-series) that read this list.
+        "default",
         "gn2p4bpt",
         "llderlii",
         "od3j1g5m",
@@ -442,6 +445,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         "v2.5_variant",
         DEFAULT_V2_MODEL_PATH,
         "auto",
+        # Deprecated alias for "auto"; kept for backward compat with users and
+        # downstream packages (e.g. tabpfn-time-series) that read this list.
+        "default",
         "2noar4o2",
         "5wof9ojf",
         "09gpqh39",

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -893,7 +893,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v2.5_real",
             "v2.5_variant",
             "v2_default",
-            "default",
+            "auto",
             "gn2p4bpt",
             "llderlii",
             "od3j1g5m",
@@ -918,6 +918,8 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
     def test_validate_model_name_with_valid_model_passes(self):
         # Should not raise any exception
+        TabPFNClassifier._validate_model_name("auto")
+        # "default" remains accepted as a backward-compatible alias for "auto".
         TabPFNClassifier._validate_model_name("default")
         TabPFNClassifier._validate_model_name("gn2p4bpt")
 
@@ -926,11 +928,13 @@ class TestTabPFNModelSelection(unittest.TestCase):
             TabPFNClassifier._validate_model_name("invalid_model")
 
     def test_model_name_to_path_returns_expected_path(self):
-        # Test default model path. Server decides.
-        expected_default_path = None
-        self.assertEqual(
+        # Test auto model path. Server decides.
+        self.assertIsNone(
+            TabPFNClassifier._model_name_to_path("classification", "auto"),
+        )
+        # "default" alias resolves the same way.
+        self.assertIsNone(
             TabPFNClassifier._model_name_to_path("classification", "default"),
-            expected_default_path,
         )
 
         # Test specific model path

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -894,6 +894,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v2.5_variant",
             "v2_default",
             "auto",
+            "default",
             "gn2p4bpt",
             "llderlii",
             "od3j1g5m",

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -852,6 +852,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v2.5_variant",
             "v2_default",
             "auto",
+            "default",
             "2noar4o2",
             "5wof9ojf",
             "09gpqh39",

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -851,7 +851,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v2.5_small-samples",
             "v2.5_variant",
             "v2_default",
-            "default",
+            "auto",
             "2noar4o2",
             "5wof9ojf",
             "09gpqh39",
@@ -875,6 +875,8 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
     def test_validate_model_name_with_valid_model_passes(self):
         # Should not raise any exception
+        TabPFNRegressor._validate_model_name("auto")
+        # "default" remains accepted as a backward-compatible alias for "auto".
         TabPFNRegressor._validate_model_name("default")
         TabPFNRegressor._validate_model_name("2noar4o2")
 
@@ -883,11 +885,13 @@ class TestTabPFNModelSelection(unittest.TestCase):
             TabPFNRegressor._validate_model_name("invalid_model")
 
     def test_model_name_to_path_returns_expected_path(self):
-        # Test default model path. Server decides.
-        expected_default_path = None
-        self.assertEqual(
+        # Test auto model path. Server decides.
+        self.assertIsNone(
+            TabPFNRegressor._model_name_to_path("regression", "auto"),
+        )
+        # "default" alias resolves the same way.
+        self.assertIsNone(
             TabPFNRegressor._model_name_to_path("regression", "default"),
-            expected_default_path,
         )
 
         # Test specific model path


### PR DESCRIPTION
* Allow `model_path=auto` (how the option is called in OSS package), still retain `default` for backwards compat
* Set `random_state=0` to match OSS package (note this is technically a breaking change)
* Set `ignore_pretraining_limits=False` (up for discussion if we actually want to keep this as-is though, curious to your thoughts @brendan-priorlabs  -- as we handle limits already in the server.

https://linear.app/priorlabs/issue/ENG-663/snapshot-align-client-and-oss-package-interface