### PR TITLE
Translate user-facing thinking_metric -> wire thinking_effort_metric

### DIFF
--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -108,7 +108,7 @@ class FitRequest(BaseModel):
     # Budget for the fit (seconds). Only consulted when `thinking_effort` is set.
     thinking_timeout_s: Optional[float] = None
     # Optimization metric for the fit. Only consulted when `thinking_effort` is set.
-    thinking_metric: Optional[str] = None
+    thinking_effort_metric: Optional[str] = None
 
 
 class FitResponse(BaseModel):

--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -407,6 +407,8 @@ class ServiceClient(Singleton):
         # The client-side `thinking_*` knobs forward 1:1 to the server's
         # top-level FitRequest fields. When the user enabled thinking via
         # `thinking_mode=True` without picking a level, default to "medium".
+        # The user-facing kwarg is `thinking_metric`; on the wire it is sent
+        # as `thinking_effort_metric` (matching the server's FitRequest schema).
         if thinking_enabled and tabpfn_config:
             thinking_effort = tabpfn_config.get("thinking_effort") or "medium"
             thinking_timeout_s = tabpfn_config.get("thinking_timeout_s")
@@ -444,7 +446,7 @@ class ServiceClient(Singleton):
                 tabpfn_config=server_tabpfn_config,
                 thinking_effort=thinking_effort,
                 thinking_timeout_s=thinking_timeout_s,
-                thinking_metric=thinking_metric,
+                thinking_effort_metric=thinking_metric,
             ),
             timeout=client_options.timeout,
             headers=client_options.headers,


### PR DESCRIPTION
## Summary

The merged renames went different directions on the two repos:

- `tabpfn-server` (#852, deployed as prod gapi) — wire field is `thinking_effort_metric`
- `tabpfn-client` (#270, this main) — public kwarg + wire field is `thinking_metric`

Result: any fit from `tabpfn-client@main` against `api.priorlabs.ai` 422s with `extra_forbidden` on `thinking_metric` — including plain v3 and v2.5 fits, because the field is serialised as `null` even when thinking is off.

This PR keeps the **public API** as `thinking_metric` (the `TabPFNClassifier` / `TabPFNRegressor` kwarg, the instance attribute, and `validate_thinking_mode`) so existing user code does not change. Only the **wire field** on `FitRequest` and the call site that builds the request body are renamed to `thinking_effort_metric` to match the server's schema.

Diff is +4/-2 across 2 files.

## Test plan

- [x] `pytest tests/unit/` — 124/124 passing
- [x] e2e fit + predict against `api.priorlabs.ai` for v3 plain, v3 thinking medium, v3 thinking high, v2.5 plain (both classification and regression)