### PR TITLE
client: drop SelectiveHTTP2Transport, use HTTP/1.1 only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "httpx[http2]>=0.25.0,<=0.28.1",
+    "httpx>=0.25.0,<=0.28.1",
     "omegaconf>=2.1.2,<=2.3.0",
     "pandas>=2.1.2,<=2.3.3",
     "password-strength>=0.0.3.post2,<=0.0.3.post2",

--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -26,7 +26,6 @@ import pandas as pd
 
 import backoff
 import httpx
-from httpx._transports.default import HTTPTransport
 from omegaconf import OmegaConf
 from tabpfn_client.browser_auth import BrowserAuthHandler
 from tabpfn_client.constants import (
@@ -187,22 +186,6 @@ class PredictionResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-class SelectiveHTTP2Transport(HTTPTransport):
-    def __init__(self, http2_paths=None, *args, **kwargs):
-        self.http2_paths = http2_paths or []
-        self.http1 = HTTPTransport(http2=False, *args, **kwargs)
-        self.http2 = HTTPTransport(http2=True, *args, **kwargs)
-
-    def handle_request(self, request):
-        if request.url.path in self.http2_paths:
-            return self.http2.handle_request(request)
-        return self.http1.handle_request(request)
-
-    def close(self) -> None:
-        self.http1.close()
-        self.http2.close()
-
-
 class ServiceClient(Singleton):
     """
     Singleton class for handling communication with the server.
@@ -215,13 +198,24 @@ class ServiceClient(Singleton):
         TABPFN_CLIENT_API_URL
         or f"{server_config.protocol}://{server_config.host}:{server_config.port}"
     )
-    fit_path = SERVER_CONFIG["endpoints"]["fit"]["path"]
-    predict_path = SERVER_CONFIG["endpoints"]["predict"]["path"]
+    # NOTE: HTTP/1.1 only. HTTP/2 used to be selectively enabled for the
+    # /tabpfn/fit and /tabpfn/predict endpoints, but the long-running
+    # thinking-mode fit kept the stream open for 5-15 min, which raced
+    # against intermediate keepalive PINGs from Cloud Run's LB. The
+    # `h2` state machine treats a PING received while the connection
+    # is CLOSED as a protocol violation and surfaces it as
+    # `httpx.LocalProtocolError("Invalid input ConnectionInputs.RECV_PING
+    # in state ConnectionState.CLOSED")` — which is NOT in the SDK's
+    # retry tuple, so the request fails hard instead of retrying.
+    # HTTP/1.1 has no PING frames and no equivalent state machine, so
+    # the race disappears. Unary POSTs against /fit and /predict don't
+    # benefit from HTTP/2's multiplexing or HPACK in any measurable way
+    # (one request per fit, dominated by the multipart body), so the
+    # tradeoff is one-sided.
     httpx_client = httpx.Client(
         base_url=base_url,
         timeout=TABPFN_CLIENT_TIMEOUT,
         headers={"Prior-Client-Version": get_client_version()},
-        transport=SelectiveHTTP2Transport(http2_paths=[fit_path, predict_path]),
         follow_redirects=True,
     )
     _access_token = None


### PR DESCRIPTION
## Summary
- Drop `SelectiveHTTP2Transport` and the `HTTPTransport` import — `ServiceClient.httpx_client` now uses HTTP/1.1 everywhere.
- Drop the `[http2]` extra from the `httpx` dependency so `h2` is no longer pulled in transitively.
- Inline comment explains *why* in case anyone is tempted to reintroduce HTTP/2 in the future.

## Why

The transport opted `/tabpfn/fit` and `/tabpfn/predict` into HTTP/2 while leaving everything else on HTTP/1.1. Both are long-running unary POSTs (thinking-mode fits keep the stream open for 5–15 min) and gain nothing measurable from HTTP/2's multiplexing or HPACK — one request per fit, multipart body dominated by raw bytes.

What HTTP/2 *did* buy us: a state-machine race.

The `h2` library treats a `PING` frame received while `ConnectionState == CLOSED` as a protocol violation (RFC 7540 §6.7 — PINGs only make sense while the connection is open). During long thinking fits, intermediate keepalive PINGs (Cloud Run's LB sends them on long-lived streams) regularly land on the client *after* the connection has been reaped by some hop, and httpx surfaces this as:

```
httpx.LocalProtocolError: Invalid input ConnectionInputs.RECV_PING in state ConnectionState.CLOSED
```

That exception class is **not** in either `_fit`'s or `_predict`'s `@backoff.on_exception` retry tuple — the tuple covers `RemoteProtocolError` (peer sent garbage) but not `LocalProtocolError` (our state machine got wrong-footed by a benign-but-out-of-order frame). So instead of being retried silently, the fit fails hard with a confusing error.

### Reproduction / evidence

A 135-fit TabArena-Medium sweep against `api.priorlabs.ai` (15 datasets × 3 folds × 3 modes: plain / thinking_medium / thinking_high) ate **6 `LocalProtocolError`s across thinking_medium + thinking_high**:

```
{"error": "Invalid input ConnectionInputs.RECV_PING in state ConnectionState.CLOSED",
 "traceback": "...httpcore/_sync/http2.py:185...raise LocalProtocolError(exc)..."}
```

Re-running the same matrix locally with `httpx_client` monkey-patched to drop the selective HTTP/2 transport cleared **all 5 missing thinking_high cells with zero protocol errors** — confirming the race disappears.

## Alternative considered

Adding `httpx.LocalProtocolError` to the retry tuple would also mask the issue, but it's strictly the worse fix:
- still leaves HTTP/2 enabled with no upside
- one retry per fit, ~5–15 min wasted on the doomed attempt
- the `h2` state machine can fail in other ways too (less common, but still in scope)

Dropping HTTP/2 entirely eliminates the class of bugs at the cost of zero observable functionality.

## Test plan
- [x] `pytest tests/unit/test_client.py` — 22/22 pass (unchanged from main).
- [x] Local rerun of 5 previously-failing thinking_high TabArena-Medium tasks under the patched client — 0 protocol errors, all 5 complete cleanly.