### PR TITLE
chore: add SECURITY.md + swap chartboost/ruff-action for astral-sh/ruff-action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3
         with:
           src: "./"
           version: 0.3.3
           args: "format --force-exclude"
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3
         with:
           src: "./"
           version: 0.3.3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,12 @@
 # Security
 
+## Supported Versions
+
+We support only the most recent minor release. Older releases do not
+receive security patches — please upgrade.
+
+## Reporting a Vulnerability
+
 Please email **security@priorlabs.ai** to report a vulnerability.
 
 We support coordinated disclosure and will acknowledge promptly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security
+
+Please email **security@priorlabs.ai** to report a vulnerability.
+
+We support coordinated disclosure and will acknowledge promptly.
+Don't file public GitHub issues for suspected vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ receive security patches — please upgrade.
 Please email **security@priorlabs.ai** to report a vulnerability.
 
 We support coordinated disclosure and will acknowledge promptly.
-Don't file public GitHub issues for suspected vulnerabilities.
+Please do not report security vulnerabilities via public GitHub issues.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` pointing reports to `security@priorlabs.ai`.
- Replace `chartboost/ruff-action@v1` with `astral-sh/ruff-action@4919ec5` (v3, SHA-pinned). chartboost stopped maintaining their fork; astral-sh is the canonical maintained one and is API-compatible (`src:`, `version:`, `args:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)