### PR TITLE
Add SageMaker BYOC client (tabpfn_client.sagemaker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,42 @@ and login (on another machine) using your access token, skipping the interactive
 tabpfn_client.set_access_token(token)
 ```
 
+## AWS SageMaker (BYOC)
+
+If you've subscribed to the TabPFN AWS Marketplace listing and deployed the container to a SageMaker real-time endpoint, you can invoke it through `tabpfn_client.sagemaker` using a near-identical scikit-learn surface. There is no PriorLabs API token in this path — you authenticate to your own AWS account, and `predict` calls are billed by AWS SageMaker rather than against your TabPFN usage allowance.
+
+Install with the optional `sagemaker` extra to pull in `boto3`:
+
+```bash
+pip install --upgrade 'tabpfn-client[sagemaker]'
+```
+
+Then point the estimator at your endpoint:
+
+```python
+from tabpfn_client.sagemaker import TabPFNClassifier, TabPFNRegressor
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
+
+clf = TabPFNClassifier(
+    endpoint_name="your-sagemaker-endpoint-name",
+    region_name="us-east-1",
+)
+clf.fit(X_train, y_train)
+clf.predict(X_test)
+clf.predict_proba(X_test)
+```
+
+Notes:
+
+- AWS credentials are resolved through the standard `boto3` credential chain (env vars, `~/.aws/credentials`, instance profile, SSO, etc.). Pass `boto_session=session` to use an explicit `boto3.Session`.
+- `fit()` is local: TabPFN is in-context, so the estimator just keeps `X_train` / `y_train` and ships them on each `predict*` call. There is no separate training job.
+- Set `use_kv_cache=True` to opt into the v3 KV-cache path on the server: the first round-trip uploads training data and captures a `model_id`; subsequent `predict*` calls reference that id and skip the training upload. This trades a stateful endpoint for lower per-call latency and payload size.
+- Constructor kwargs mirror the public `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` so the same code is portable between the managed API and a SageMaker endpoint, modulo `endpoint_name` / `region_name`.
+
 ## Join Our Community
 
 We're building the future of tabular machine learning and would love your involvement! Here's how you can participate and get help:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ Notes:
 - Set `use_kv_cache=True` to opt into the v3 KV-cache path on the server: the first round-trip uploads training data and captures a `model_id`; subsequent `predict*` calls reference that id and skip the training upload. This trades a stateful endpoint for lower per-call latency and payload size.
 - Constructor kwargs mirror the public `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` so the same code is portable between the managed API and a SageMaker endpoint, modulo `endpoint_name` / `region_name`.
 
+Thinking mode is supported on SageMaker by passing the same `thinking_mode` / `thinking_effort` / `thinking_timeout_s` / `thinking_metric` kwargs:
+
+```python
+clf = TabPFNClassifier(
+    endpoint_name="your-sagemaker-endpoint-name",
+    region_name="us-east-1",
+    thinking_mode=True,
+    thinking_effort="medium",
+)
+```
+
+The first `predict*` call after `fit()` runs the autogluon-wrapped fit on the endpoint and can take from tens of seconds up to several minutes depending on `thinking_effort` and data size; the fitted model is cached on the endpoint and subsequent calls are fast. Caching is **required** when thinking is enabled (the client sets `use_kv_cache=True` automatically) — without it every prediction would redo the fit, which would exceed SageMaker's synchronous invoke window. Only `thinking_effort="medium"` is reliable within the real-time endpoint's ~60 s sync window for the *first* call; `"high"` may exceed it and is currently best-effort.
+
 ## Join Our Community
 
 We're building the future of tabular machine learning and would love your involvement! Here's how you can participate and get help:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ clf = TabPFNClassifier(
 )
 ```
 
-The first `predict*` call after `fit()` runs the autogluon-wrapped fit on the endpoint and can take from tens of seconds up to several minutes depending on `thinking_effort` and data size; the fitted model is cached on the endpoint and subsequent calls are fast. Caching is **required** when thinking is enabled (the client sets `use_kv_cache=True` automatically) — without it every prediction would redo the fit, which would exceed SageMaker's synchronous invoke window. Only `thinking_effort="medium"` is reliable within the real-time endpoint's ~60 s sync window for the *first* call; `"high"` may exceed it and is currently best-effort.
+The first `predict*` call after `fit()` runs the fit on the endpoint and can take from tens of seconds up to several minutes depending on `thinking_effort` and data size; the fitted model is cached on the endpoint and subsequent calls are fast. Caching is **required** when thinking is enabled (the client sets `use_kv_cache=True` automatically) — without it every prediction would redo the fit, which would exceed SageMaker's synchronous invoke window. Only `thinking_effort="medium"` is reliable within the real-time endpoint's ~60 s sync window for the *first* call; `"high"` may exceed it and is currently best-effort.
 
 ## Join Our Community
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ clf.predict_proba(X_test)
 Notes:
 
 - AWS credentials are resolved through the standard `boto3` credential chain (env vars, `~/.aws/credentials`, instance profile, SSO, etc.). Pass `boto_session=session` to use an explicit `boto3.Session`.
-- `fit()` is local: TabPFN is in-context, so the estimator just keeps `X_train` / `y_train` and ships them on each `predict*` call. There is no separate training job.
-- Set `use_kv_cache=True` to opt into the v3 KV-cache path on the server: the first round-trip uploads training data and captures a `model_id`; subsequent `predict*` calls reference that id and skip the training upload. This trades a stateful endpoint for lower per-call latency and payload size.
+- `fit()` does not call the endpoint — it stores `X_train` / `y_train` on the estimator. Training data is shipped with the next `predict*` call, which is where the actual fit runs on the endpoint. There is no separate training job.
+- `use_kv_cache=True` opts into the v3 KV-cache path on the server: the first `predict*` round-trip uploads training data and captures a `model_id`, and subsequent calls send only `X_test` and the id. Default to `True` when you'll call `predict*` more than once on the same training data; leave it off if every call uses a different training set (no reuse), since the cache becomes dead weight on the endpoint.
 - Constructor kwargs mirror the public `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` so the same code is portable between the managed API and a SageMaker endpoint, modulo `endpoint_name` / `region_name`.
 
 Thinking mode is supported on SageMaker by passing the same `thinking_mode` / `thinking_effort` / `thinking_timeout_s` / `thinking_metric` kwargs:

--- a/examples/sagemaker/tabpfn-3-sample.ipynb
+++ b/examples/sagemaker/tabpfn-3-sample.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TabPFN-3 on Amazon SageMaker — sample notebook\n",
+    "\n",
+    "End-to-end walkthrough for buyers of the **TabPFN-3** or **TabPFN-3 (+Thinking)** AWS Marketplace listings.\n",
+    "Covers: subscription → deploy as a SageMaker async-inference endpoint → invoke via the `tabpfn_client.sagemaker` Python SDK → clean up.\n",
+    "\n",
+    "**Prerequisites**\n",
+    "\n",
+    "- An active subscription to one of the listings:\n",
+    "  - [TabPFN-3](https://aws.amazon.com/marketplace/pp/prodview-) (base SKU — single forward pass)\n",
+    "  - [TabPFN-3 (+Thinking)](https://aws.amazon.com/marketplace/pp/prodview-) (full SKU — base + optional Thinking mode)\n",
+    "- An AWS account with permission to create SageMaker `Model`, `EndpointConfig`, and `Endpoint` resources, and to read/write the S3 bucket you use for async input/output.\n",
+    "- A SageMaker execution role ARN that trusts `sagemaker.amazonaws.com` and has read access to that S3 bucket.\n",
+    "- `pip install --upgrade 'tabpfn-client[sagemaker]'`\n",
+    "\n",
+    "The notebook is identical for both SKUs; the only difference is which Model Package ARN you paste below and whether you pass `thinking_effort` at invoke time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "After subscribing to the listing, AWS shows you the Model Package ARN in the *Continue to configuration* step.\n",
+    "Copy the ARN for your AWS region and paste it below. The ARN looks like\n",
+    "`arn:aws:sagemaker:us-east-1:<acct>:model-package/<some-uuid>`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "\n",
+    "import boto3\n",
+    "\n",
+    "# >>> EDIT THESE <<<\n",
+    "MODEL_PACKAGE_ARN = \"arn:aws:sagemaker:us-east-1:<account>:model-package/<id>\"\n",
+    "EXECUTION_ROLE_ARN = \"arn:aws:iam::<account>:role/<SageMakerExecutionRole>\"\n",
+    "ASYNC_S3_BUCKET = \"<your-async-io-bucket>\"  # bucket the execution role can read+write\n",
+    "REGION = \"us-east-1\"\n",
+    "\n",
+    "# Derived names (no need to change)\n",
+    "MODEL_NAME = \"tabpfn-3-sample\"\n",
+    "ENDPOINT_CONFIG_NAME = f\"{MODEL_NAME}-cfg\"\n",
+    "ENDPOINT_NAME = f\"{MODEL_NAME}-endpoint\"\n",
+    "\n",
+    "sm = boto3.client(\"sagemaker\", region_name=REGION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Deploy as a SageMaker Async Inference endpoint\n",
+    "\n",
+    "Async inference is the recommended deployment for any non-trivial dataset.\n",
+    "Synchronous real-time invocations cap payloads at 6 MB and processing at 60 seconds,\n",
+    "which tabular workloads regularly exceed. Async lifts both caps (1 GB payload,\n",
+    "60 min processing) at the cost of an S3-mediated request/response round-trip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.create_model(\n",
+    "    ModelName=MODEL_NAME,\n",
+    "    ExecutionRoleArn=EXECUTION_ROLE_ARN,\n",
+    "    PrimaryContainer={\"ModelPackageName\": MODEL_PACKAGE_ARN},\n",
+    ")\n",
+    "\n",
+    "sm.create_endpoint_config(\n",
+    "    EndpointConfigName=ENDPOINT_CONFIG_NAME,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"VariantName\": \"primary\",\n",
+    "            \"ModelName\": MODEL_NAME,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"InstanceType\": \"ml.g5.xlarge\",\n",
+    "            \"InitialVariantWeight\": 1.0,\n",
+    "            \"ModelDataDownloadTimeoutInSeconds\": 600,\n",
+    "            \"ContainerStartupHealthCheckTimeoutInSeconds\": 600,\n",
+    "        }\n",
+    "    ],\n",
+    "    AsyncInferenceConfig={\n",
+    "        \"ClientConfig\": {\"MaxConcurrentInvocationsPerInstance\": 4},\n",
+    "        \"OutputConfig\": {\n",
+    "            \"S3OutputPath\": f\"s3://{ASYNC_S3_BUCKET}/tabpfn-3-async/outputs/\",\n",
+    "            \"S3FailurePath\": f\"s3://{ASYNC_S3_BUCKET}/tabpfn-3-async/failures/\",\n",
+    "        },\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "sm.create_endpoint(EndpointName=ENDPOINT_NAME, EndpointConfigName=ENDPOINT_CONFIG_NAME)\n",
+    "\n",
+    "print(\"Endpoint creating; waiting for InService (typically 6-10 minutes)...\")\n",
+    "sm.get_waiter(\"endpoint_in_service\").wait(EndpointName=ENDPOINT_NAME)\n",
+    "print(\"Endpoint is InService.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Invoke the endpoint with the `tabpfn_client` Python SDK\n",
+    "\n",
+    "The `tabpfn_client.sagemaker.TabPFNClassifier` / `TabPFNRegressor` classes wrap\n",
+    "`boto3.client(\"sagemaker-runtime\")` with a scikit-learn-style API and handle the\n",
+    "async staging-input / poll-output round-trip for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "from tabpfn_client.sagemaker import TabPFNClassifier\n",
+    "\n",
+    "X, y = load_breast_cancer(return_X_y=True)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)\n",
+    "\n",
+    "clf = TabPFNClassifier(\n",
+    "    endpoint_name=ENDPOINT_NAME,\n",
+    "    region_name=REGION,\n",
+    "    use_async=True,\n",
+    "    s3_bucket=ASYNC_S3_BUCKET,\n",
+    ")\n",
+    "clf.fit(X_train, y_train)\n",
+    "\n",
+    "y_pred = clf.predict(X_test)\n",
+    "proba = clf.predict_proba(X_test)\n",
+    "print(\"prediction shape:\", proba.shape, \" accuracy:\", (y_pred == y_test).mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Thinking mode (TabPFN-3 (+Thinking) SKU only)\n",
+    "\n",
+    "If you subscribed to the **TabPFN-3 (+Thinking)** listing, the same endpoint also accepts\n",
+    "an optional `thinking_effort` parameter (`\"medium\"` or `\"high\"`) that engages Thinking mode\n",
+    "for that request. Thinking mode applies additional inference-time computation on top of\n",
+    "TabPFN-3 to push prediction quality further. Omit `thinking_effort` to use the base\n",
+    "single-forward-pass behavior — both modes work on the same endpoint and are selected per call.\n",
+    "\n",
+    "Skip this cell if you subscribed to the base TabPFN-3 listing (the server returns 422 on\n",
+    "thinking requests for the base SKU)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clf_thinking = TabPFNClassifier(\n",
+    "    endpoint_name=ENDPOINT_NAME,\n",
+    "    region_name=REGION,\n",
+    "    use_async=True,\n",
+    "    s3_bucket=ASYNC_S3_BUCKET,\n",
+    "    thinking_effort=\"medium\",  # or \"high\"\n",
+    ")\n",
+    "clf_thinking.fit(X_train, y_train)\n",
+    "\n",
+    "y_pred_t = clf_thinking.predict(X_test)\n",
+    "proba_t = clf_thinking.predict_proba(X_test)\n",
+    "print(\"thinking prediction shape:\", proba_t.shape, \" accuracy:\", (y_pred_t == y_test).mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Clean up\n",
+    "\n",
+    "Endpoints bill per instance-hour while they're `InService`. Tear down once you're done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.delete_endpoint(EndpointName=ENDPOINT_NAME)\n",
+    "sm.delete_endpoint_config(EndpointConfigName=ENDPOINT_CONFIG_NAME)\n",
+    "sm.delete_model(ModelName=MODEL_NAME)\n",
+    "print(\"Endpoint + config + model deleted.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/sagemaker/tabpfn-3-sample.ipynb
+++ b/examples/sagemaker/tabpfn-3-sample.ipynb
@@ -3,23 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# TabPFN-3 on Amazon SageMaker — sample notebook\n",
-    "\n",
-    "End-to-end walkthrough for buyers of the **TabPFN-3** or **TabPFN-3 (+Thinking)** AWS Marketplace listings.\n",
-    "Covers: subscription → deploy as a SageMaker async-inference endpoint → invoke via the `tabpfn_client.sagemaker` Python SDK → clean up.\n",
-    "\n",
-    "**Prerequisites**\n",
-    "\n",
-    "- An active subscription to one of the listings:\n",
-    "  - [TabPFN-3](https://aws.amazon.com/marketplace/pp/prodview-) (base SKU — single forward pass)\n",
-    "  - [TabPFN-3 (+Thinking)](https://aws.amazon.com/marketplace/pp/prodview-) (full SKU — base + optional Thinking mode)\n",
-    "- An AWS account with permission to create SageMaker `Model`, `EndpointConfig`, and `Endpoint` resources, and to read/write the S3 bucket you use for async input/output.\n",
-    "- A SageMaker execution role ARN that trusts `sagemaker.amazonaws.com` and has read access to that S3 bucket.\n",
-    "- `pip install --upgrade 'tabpfn-client[sagemaker]'`\n",
-    "\n",
-    "The notebook is identical for both SKUs; the only difference is which Model Package ARN you paste below and whether you pass `thinking_effort` at invoke time."
-   ]
+   "source": "# TabPFN-3 on Amazon SageMaker — sample notebook\n\nEnd-to-end walkthrough for buyers of the **TabPFN-3** or **TabPFN-3 (+Thinking)** AWS Marketplace listings.\nCovers: subscription → deploy as a SageMaker async-inference endpoint → invoke via the `tabpfn_client.sagemaker` Python SDK → clean up.\n\n**Prerequisites**\n\n- An active AWS Marketplace subscription to one of the listings: **TabPFN-3** (base SKU — single forward pass) or **TabPFN-3 (+Thinking)** (full SKU — base + optional Thinking mode).\n- An AWS account with permission to create SageMaker `Model`, `EndpointConfig`, and `Endpoint` resources, and to read/write the S3 bucket you use for async input/output.\n- A SageMaker execution role ARN that trusts `sagemaker.amazonaws.com` and has read access to that S3 bucket.\n- `pip install --upgrade 'tabpfn-client[sagemaker]'`\n\nThe notebook is identical for both SKUs; the only difference is which Model Package ARN you paste below and whether you pass `thinking_effort` at invoke time."
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dependencies = [
     "pyarrow>=14.0.0,<=23.0.1",
 ]
 
+[project.optional-dependencies]
+sagemaker = ["boto3>=1.34"]
+
 [project.urls]
 documentation = "https://priorlabs.ai/docs"
 source = "https://github.com/priorlabs/tabpfn-client"

--- a/src/tabpfn_client/sagemaker/__init__.py
+++ b/src/tabpfn_client/sagemaker/__init__.py
@@ -1,11 +1,6 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 #  Licensed under the Apache License, Version 2.0
 """SageMaker BYOC client for TabPFN.
-
-Users subscribed to the TabPFN AWS Marketplace listing deploy the BYOC
-container to a SageMaker real-time endpoint and invoke it through this
-submodule. The wire protocol is the inline JSON form accepted by the
-container's /invocations route; auth is the standard boto3 credential chain.
 
     from tabpfn_client.sagemaker import TabPFNClassifier, TabPFNRegressor
 """

--- a/src/tabpfn_client/sagemaker/__init__.py
+++ b/src/tabpfn_client/sagemaker/__init__.py
@@ -1,0 +1,16 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+"""SageMaker BYOC client for TabPFN.
+
+Users subscribed to the TabPFN AWS Marketplace listing deploy the BYOC
+container to a SageMaker real-time endpoint and invoke it through this
+submodule. The wire protocol is the inline JSON form accepted by the
+container's /invocations route; auth is the standard boto3 credential chain.
+
+    from tabpfn_client.sagemaker import TabPFNClassifier, TabPFNRegressor
+"""
+
+from tabpfn_client.sagemaker.estimator import TabPFNClassifier, TabPFNRegressor
+
+
+__all__ = ["TabPFNClassifier", "TabPFNRegressor"]

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -1,20 +1,10 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 #  Licensed under the Apache License, Version 2.0
-"""scikit-learn estimators that invoke a TabPFN SageMaker BYOC endpoint.
+"""scikit-learn estimators for the TabPFN SageMaker BYOC endpoint.
 
-The endpoint is the container defined in `dists/marketplaces/aws` in the
-`tabpfn-server` repo. It accepts a single inline JSON body at POST
-/invocations matching `prior.predictor.requests.PredictRequest`, and returns
-`{"prediction": ..., "metadata": ..., "model_id": ...}`. The estimators here
-build that body from the sklearn-style call surface, dispatch via
-`boto3.client("sagemaker-runtime").invoke_endpoint`, and return the
-prediction as a numpy array.
-
-`fit()` is local-only: TabPFN is in-context, so we just keep X/y around and
-ship them with each `predict*` call. The optional `use_kv_cache=True` path
-opts into the server's V3 FIT_WITH_CACHE mode — the first round-trip uploads
-training data and captures a `model_id`; subsequent predicts skip the upload
-and reference that id.
+Mirrors the `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` surface;
+each `predict*` call dispatches via `boto3.client("sagemaker-runtime")`
+against your SageMaker endpoint. `fit()` is local (TabPFN is in-context).
 """
 
 from __future__ import annotations
@@ -59,15 +49,7 @@ def _to_jsonable(X: Any) -> list:
 
 
 class _SagemakerBase(BaseEstimator):
-    """Shared invoke_endpoint plumbing for SageMaker TabPFN estimators.
-
-    Subclasses set `_TASK`. Constructor kwargs mirror the public
-    `tabpfn_client.TabPFNClassifier` so user code is portable; everything but
-    the SageMaker-specific bits is forwarded into `task_config.tabpfn_config`
-    on the wire. `model_path` is currently dropped server-side (the active
-    checkpoint is whatever was baked into the model artifact); we keep it on
-    the constructor for API parity.
-    """
+    """Shared invoke_endpoint plumbing for the SageMaker TabPFN estimators."""
 
     _TASK: str = ""  # overridden by subclasses
 
@@ -115,10 +97,7 @@ class _SagemakerBase(BaseEstimator):
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.use_kv_cache = use_kv_cache
-        # Async Inference path: required for payloads > 6 MB or compute > 60 s.
-        # When True, requests stage input through S3 and poll the output S3
-        # location SageMaker writes back. The endpoint must be configured with
-        # AsyncInferenceConfig.
+        # Async Inference path: needed for payloads > 6 MB or compute > 60 s.
         self.use_async = use_async
         self.s3_bucket = s3_bucket
         self.s3_prefix = s3_prefix
@@ -131,9 +110,7 @@ class _SagemakerBase(BaseEstimator):
 
     @property
     def _effective_use_kv_cache(self) -> bool:
-        # Thinking implies caching: without it every predict redoes the
-        # autogluon HPO sweep. The server enforces this too; we mirror it
-        # client-side so the wire body always agrees.
+        # Thinking implies caching: without it every predict redoes the fit.
         return self.use_kv_cache or self._thinking_active
 
     def _build_tabpfn_config(self) -> Dict[str, Any]:
@@ -147,10 +124,6 @@ class _SagemakerBase(BaseEstimator):
             "inference_config": self.inference_config,
             "fit_mode": "fit_with_cache" if self._effective_use_kv_cache else "fit_preprocessors",
         }
-        # paper_version is OSS TabPFN-only — server's tagged-union forbids
-        # extras. balance_probabilities lives only on ClassifierTabPFNConfig.
-        # thinking_* fields live at the top of the body, not under
-        # tabpfn_config — see `_invoke`.
         if self._TASK == "classification":
             cfg["balance_probabilities"] = self.balance_probabilities
         if self.model_path not in ("auto", "default"):
@@ -158,9 +131,7 @@ class _SagemakerBase(BaseEstimator):
         return cfg
 
     def _build_thinking_block(self) -> Dict[str, Any]:
-        """Top-level wire fields for thinking-mode. Sibling of
-        `task_config`, mirroring gapi's `FitRequest` shape. Empty when
-        thinking isn't active so callers can splat unconditionally."""
+        """Top-level wire fields for thinking-mode. Empty when inactive."""
         if not self._thinking_active:
             return {}
         block: Dict[str, Any] = {
@@ -173,8 +144,7 @@ class _SagemakerBase(BaseEstimator):
         return block
 
     def _runtime_client(self):
-        # Cached on the instance: boto3 service-model load + credential
-        # resolution is non-trivial and we don't want it on every predict.
+        # Cache the client: boto3 client construction is expensive per call.
         client = getattr(self, "_cached_client", None)
         if client is not None:
             return client
@@ -203,15 +173,13 @@ class _SagemakerBase(BaseEstimator):
         return client
 
     def __getstate__(self) -> Dict[str, Any]:
-        # boto3 clients aren't pickleable. Strip the cache so the estimator
-        # stays compatible with sklearn's pickle-based parallel/grid utilities.
+        # boto3 clients aren't pickleable; strip the cache for sklearn pickling.
         state = self.__dict__.copy()
         state.pop("_cached_client", None)
         state.pop("_cached_s3", None)
         return state
 
     def fit(self, X: Any, y: Any) -> "_SagemakerBase":
-        # X must be 2D; only DataFrame/array. y can be 1D (Series/array) or 2D.
         X_arr = X if isinstance(X, pd.DataFrame) else np.asarray(X)
         y_arr = y if isinstance(y, (pd.DataFrame, pd.Series)) else np.asarray(y)
         if X_arr.shape[0] != y_arr.shape[0]:
@@ -249,9 +217,7 @@ class _SagemakerBase(BaseEstimator):
             body["context"] = {"model_id": self._cached_model_id}
         else:
             body["X_train"] = _to_jsonable(self.X_train_)
-            # `y_train` on the wire is 2D (n_samples, 1) per PredictRequest.
-            # np.asarray handles pd.Series too, so the single-path form covers
-            # ndarray / list / DataFrame / Series uniformly.
+            # y_train on the wire is 2D (n_samples, 1).
             y_arr = np.asarray(self.y_train_)
             if y_arr.ndim == 1:
                 y_arr = y_arr.reshape(-1, 1)
@@ -266,8 +232,6 @@ class _SagemakerBase(BaseEstimator):
                 Accept="application/json",
                 Body=body_bytes,
             )
-            # StreamingBody is file-like; json.load avoids buffering the full
-            # response in memory, which matters for output_type="full".
             payload = json.load(resp["Body"])
         if self._effective_use_kv_cache:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -137,15 +137,31 @@ class _SagemakerBase(BaseEstimator):
         return cfg
 
     def _runtime_client(self):
+        # Cached on the instance: boto3 service-model load + credential
+        # resolution is non-trivial and we don't want it on every predict.
+        client = getattr(self, "_cached_client", None)
+        if client is not None:
+            return client
         _require_boto3()
         if self.boto_session is not None:
-            return self.boto_session.client("sagemaker-runtime")
-        if self.region_name is not None:
-            return boto3.client("sagemaker-runtime", region_name=self.region_name)
-        return boto3.client("sagemaker-runtime")
+            client = self.boto_session.client("sagemaker-runtime")
+        elif self.region_name is not None:
+            client = boto3.client("sagemaker-runtime", region_name=self.region_name)
+        else:
+            client = boto3.client("sagemaker-runtime")
+        self._cached_client = client
+        return client
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # boto3 clients aren't pickleable. Strip the cache so the estimator
+        # stays compatible with sklearn's pickle-based parallel/grid utilities.
+        state = self.__dict__.copy()
+        state.pop("_cached_client", None)
+        return state
 
     def fit(self, X: Any, y: Any) -> "_SagemakerBase":
-        X_arr = X if isinstance(X, (pd.DataFrame, pd.Series)) else np.asarray(X)
+        # X must be 2D; only DataFrame/array. y can be 1D (Series/array) or 2D.
+        X_arr = X if isinstance(X, pd.DataFrame) else np.asarray(X)
         y_arr = y if isinstance(y, (pd.DataFrame, pd.Series)) else np.asarray(y)
         if X_arr.shape[0] != y_arr.shape[0]:
             raise ValueError(
@@ -155,6 +171,8 @@ class _SagemakerBase(BaseEstimator):
         self.X_train_ = X_arr
         self.y_train_ = y_arr
         self._cached_model_id: Optional[str] = None
+        if self._TASK == "classification":
+            self.classes_ = np.unique(y_arr)
         return self
 
     def _invoke(self, X_test: Any, output_type: str) -> Dict[str, Any]:

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -175,13 +175,21 @@ class _SagemakerBase(BaseEstimator):
             self.classes_ = np.unique(y_arr)
         return self
 
-    def _invoke(self, X_test: Any, output_type: str) -> Dict[str, Any]:
+    def _invoke(
+        self,
+        X_test: Any,
+        output_type: str,
+        predict_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         check_is_fitted(self, ["X_train_", "y_train_"])
+        params: Dict[str, Any] = {"output_type": output_type}
+        if predict_params:
+            params.update(predict_params)
         body: Dict[str, Any] = {
             "task_config": {
                 "task": self._TASK,
                 "tabpfn_config": self._build_tabpfn_config(),
-                "predict_params": {"output_type": output_type},
+                "predict_params": params,
             },
             "X_test": _to_jsonable(X_test),
         }
@@ -190,21 +198,21 @@ class _SagemakerBase(BaseEstimator):
         else:
             body["X_train"] = _to_jsonable(self.X_train_)
             # `y_train` on the wire is 2D (n_samples, 1) per PredictRequest.
-            y = self.y_train_
-            if isinstance(y, pd.Series):
-                body["y_train"] = y.to_frame().values.tolist()
-            else:
-                y_arr = np.asarray(y)
-                if y_arr.ndim == 1:
-                    y_arr = y_arr.reshape(-1, 1)
-                body["y_train"] = y_arr.tolist()
+            # np.asarray handles pd.Series too, so the single-path form covers
+            # ndarray / list / DataFrame / Series uniformly.
+            y_arr = np.asarray(self.y_train_)
+            if y_arr.ndim == 1:
+                y_arr = y_arr.reshape(-1, 1)
+            body["y_train"] = y_arr.tolist()
         resp = self._runtime_client().invoke_endpoint(
             EndpointName=self.endpoint_name,
             ContentType="application/json",
             Accept="application/json",
             Body=json.dumps(body).encode("utf-8"),
         )
-        payload = json.loads(resp["Body"].read())
+        # StreamingBody is file-like; json.load avoids buffering the full
+        # response in memory, which matters for output_type="full".
+        payload = json.load(resp["Body"])
         if self.use_kv_cache:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id
         return payload
@@ -238,12 +246,22 @@ class TabPFNClassifier(_SagemakerBase, ClassifierMixin):
 class TabPFNRegressor(_SagemakerBase, RegressorMixin):
     """TabPFN regressor backed by a SageMaker real-time endpoint.
 
-    `output_type` defaults to "mean"; pass "median", "mode", or "full" for
-    the alternative distributional outputs the server exposes.
+    `output_type` defaults to "mean"; pass "median", "mode", "full", or
+    "quantiles" for the alternative distributional outputs the server
+    exposes. When `output_type="quantiles"`, `quantiles` selects the cut
+    points (each in [0, 1]).
     """
 
     _TASK = "regression"
 
-    def predict(self, X: Any, output_type: str = "mean") -> np.ndarray:
-        result = self._invoke(X, output_type=output_type)
+    def predict(
+        self,
+        X: Any,
+        output_type: str = "mean",
+        quantiles: Optional[list] = None,
+    ) -> np.ndarray:
+        predict_params: Dict[str, Any] = {}
+        if quantiles is not None:
+            predict_params["quantiles"] = quantiles
+        result = self._invoke(X, output_type=output_type, predict_params=predict_params)
         return np.asarray(result["prediction"])

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -1,0 +1,231 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+"""scikit-learn estimators that invoke a TabPFN SageMaker BYOC endpoint.
+
+The endpoint is the container defined in `dists/marketplaces/aws` in the
+`tabpfn-server` repo. It accepts a single inline JSON body at POST
+/invocations matching `prior.predictor.requests.PredictRequest`, and returns
+`{"prediction": ..., "metadata": ..., "model_id": ...}`. The estimators here
+build that body from the sklearn-style call surface, dispatch via
+`boto3.client("sagemaker-runtime").invoke_endpoint`, and return the
+prediction as a numpy array.
+
+`fit()` is local-only: TabPFN is in-context, so we just keep X/y around and
+ship them with each `predict*` call. The optional `use_kv_cache=True` path
+opts into the server's V3 FIT_WITH_CACHE mode — the first round-trip uploads
+training data and captures a `model_id`; subsequent predicts skip the upload
+and reference that id.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Literal, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+from sklearn.utils.validation import check_is_fitted
+
+try:
+    import boto3  # type: ignore[import-untyped]
+
+    _BOTO3_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    boto3 = None  # type: ignore[assignment]
+    _BOTO3_AVAILABLE = False
+
+
+ThinkingEffort = Literal["medium", "high"]
+
+
+def _require_boto3() -> None:
+    if not _BOTO3_AVAILABLE:
+        raise ImportError(
+            "boto3 is required for tabpfn_client.sagemaker. "
+            "Install with: pip install 'tabpfn-client[sagemaker]'"
+        )
+
+
+def _to_jsonable(X: Any) -> list:
+    """Coerce numpy / pandas inputs to plain Python lists for JSON."""
+    if isinstance(X, pd.DataFrame):
+        return X.values.tolist()
+    if isinstance(X, pd.Series):
+        return X.tolist()
+    return np.asarray(X).tolist()
+
+
+class _SagemakerBase(BaseEstimator):
+    """Shared invoke_endpoint plumbing for SageMaker TabPFN estimators.
+
+    Subclasses set `_TASK`. Constructor kwargs mirror the public
+    `tabpfn_client.TabPFNClassifier` so user code is portable; everything but
+    the SageMaker-specific bits is forwarded into `task_config.tabpfn_config`
+    on the wire. `model_path` is currently dropped server-side (the active
+    checkpoint is whatever was baked into the model artifact); we keep it on
+    the constructor for API parity.
+    """
+
+    _TASK: str = ""  # overridden by subclasses
+
+    def __init__(
+        self,
+        endpoint_name: str,
+        region_name: Optional[str] = None,
+        boto_session: Optional[Any] = None,
+        model_path: str = "auto",
+        n_estimators: int = 8,
+        softmax_temperature: float = 0.9,
+        balance_probabilities: bool = False,
+        average_before_softmax: bool = False,
+        ignore_pretraining_limits: bool = True,
+        inference_precision: Literal["autocast", "auto"] = "auto",
+        random_state: Optional[int] = 0,
+        inference_config: Optional[Dict[str, Any]] = None,
+        paper_version: bool = False,
+        thinking_mode: bool = False,
+        thinking_effort: Optional[ThinkingEffort] = None,
+        thinking_timeout_s: Optional[float] = None,
+        thinking_metric: Optional[str] = None,
+        use_kv_cache: bool = False,
+    ):
+        self.endpoint_name = endpoint_name
+        self.region_name = region_name
+        self.boto_session = boto_session
+        self.model_path = model_path
+        self.n_estimators = n_estimators
+        self.softmax_temperature = softmax_temperature
+        self.balance_probabilities = balance_probabilities
+        self.average_before_softmax = average_before_softmax
+        self.ignore_pretraining_limits = ignore_pretraining_limits
+        self.inference_precision = inference_precision
+        self.random_state = random_state
+        self.inference_config = inference_config
+        self.paper_version = paper_version
+        self.thinking_mode = thinking_mode
+        self.thinking_effort = thinking_effort
+        self.thinking_timeout_s = thinking_timeout_s
+        self.thinking_metric = thinking_metric
+        self.use_kv_cache = use_kv_cache
+
+    def _build_tabpfn_config(self) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {
+            "n_estimators": self.n_estimators,
+            "softmax_temperature": self.softmax_temperature,
+            "average_before_softmax": self.average_before_softmax,
+            "ignore_pretraining_limits": self.ignore_pretraining_limits,
+            "inference_precision": self.inference_precision,
+            "random_state": self.random_state,
+            "inference_config": self.inference_config,
+            "fit_mode": "fit_with_cache" if self.use_kv_cache else "fit_preprocessors",
+        }
+        # paper_version is OSS TabPFN-only — server's tagged-union forbids
+        # extras. balance_probabilities lives only on ClassifierTabPFNConfig.
+        if self._TASK == "classification":
+            cfg["balance_probabilities"] = self.balance_probabilities
+        if self.thinking_mode or self.thinking_effort is not None:
+            cfg["thinking_mode"] = True
+            if self.thinking_effort is not None:
+                cfg["thinking_effort"] = self.thinking_effort
+            if self.thinking_timeout_s is not None:
+                cfg["thinking_timeout_s"] = self.thinking_timeout_s
+            if self.thinking_metric is not None:
+                cfg["thinking_metric"] = self.thinking_metric
+        if self.model_path not in ("auto", "default"):
+            cfg["model_path"] = self.model_path
+        return cfg
+
+    def _runtime_client(self):
+        _require_boto3()
+        if self.boto_session is not None:
+            return self.boto_session.client("sagemaker-runtime")
+        if self.region_name is not None:
+            return boto3.client("sagemaker-runtime", region_name=self.region_name)
+        return boto3.client("sagemaker-runtime")
+
+    def fit(self, X: Any, y: Any) -> "_SagemakerBase":
+        X_arr = X if isinstance(X, (pd.DataFrame, pd.Series)) else np.asarray(X)
+        y_arr = y if isinstance(y, (pd.DataFrame, pd.Series)) else np.asarray(y)
+        if X_arr.shape[0] != y_arr.shape[0]:
+            raise ValueError(
+                f"X and y must have the same number of samples; "
+                f"got X={X_arr.shape}, y={y_arr.shape}"
+            )
+        self.X_train_ = X_arr
+        self.y_train_ = y_arr
+        self._cached_model_id: Optional[str] = None
+        return self
+
+    def _invoke(self, X_test: Any, output_type: str) -> Dict[str, Any]:
+        check_is_fitted(self, ["X_train_", "y_train_"])
+        body: Dict[str, Any] = {
+            "task_config": {
+                "task": self._TASK,
+                "tabpfn_config": self._build_tabpfn_config(),
+                "predict_params": {"output_type": output_type},
+            },
+            "X_test": _to_jsonable(X_test),
+        }
+        if self.use_kv_cache and self._cached_model_id is not None:
+            body["context"] = {"model_id": self._cached_model_id}
+        else:
+            body["X_train"] = _to_jsonable(self.X_train_)
+            # `y_train` on the wire is 2D (n_samples, 1) per PredictRequest.
+            y = self.y_train_
+            if isinstance(y, pd.Series):
+                body["y_train"] = y.to_frame().values.tolist()
+            else:
+                y_arr = np.asarray(y)
+                if y_arr.ndim == 1:
+                    y_arr = y_arr.reshape(-1, 1)
+                body["y_train"] = y_arr.tolist()
+        resp = self._runtime_client().invoke_endpoint(
+            EndpointName=self.endpoint_name,
+            ContentType="application/json",
+            Accept="application/json",
+            Body=json.dumps(body).encode("utf-8"),
+        )
+        payload = json.loads(resp["Body"].read())
+        if self.use_kv_cache:
+            self._cached_model_id = payload.get("model_id") or self._cached_model_id
+        return payload
+
+
+class TabPFNClassifier(_SagemakerBase, ClassifierMixin):
+    """TabPFN classifier backed by a SageMaker real-time endpoint.
+
+    Example:
+        from tabpfn_client.sagemaker import TabPFNClassifier
+        clf = TabPFNClassifier(
+            endpoint_name="tabpfn-sm-alpha-v3-thinking-001",
+            region_name="us-east-1",
+        )
+        clf.fit(X_train, y_train)
+        clf.predict(X_test)
+        clf.predict_proba(X_test)
+    """
+
+    _TASK = "classification"
+
+    def predict(self, X: Any) -> np.ndarray:
+        result = self._invoke(X, output_type="preds")
+        return np.asarray(result["prediction"])
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        result = self._invoke(X, output_type="probas")
+        return np.asarray(result["prediction"])
+
+
+class TabPFNRegressor(_SagemakerBase, RegressorMixin):
+    """TabPFN regressor backed by a SageMaker real-time endpoint.
+
+    `output_type` defaults to "mean"; pass "median", "mode", or "full" for
+    the alternative distributional outputs the server exposes.
+    """
+
+    _TASK = "regression"
+
+    def predict(self, X: Any, output_type: str = "mean") -> np.ndarray:
+        result = self._invoke(X, output_type=output_type)
+        return np.asarray(result["prediction"])

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -4,7 +4,9 @@
 
 Mirrors the `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` surface;
 each `predict*` call dispatches via `boto3.client("sagemaker-runtime")`
-against your SageMaker endpoint. `fit()` is local (TabPFN is in-context).
+against your SageMaker endpoint. `fit()` does not call the endpoint —
+it just stores `X` / `y` on the estimator. The training data is shipped
+to the endpoint on the next `predict*` call, where the actual fit runs.
 """
 
 from __future__ import annotations
@@ -319,13 +321,7 @@ class TabPFNClassifier(_SagemakerBase, ClassifierMixin):
 
 
 class TabPFNRegressor(_SagemakerBase, RegressorMixin):
-    """TabPFN regressor backed by a SageMaker real-time endpoint.
-
-    `output_type` defaults to "mean"; pass "median", "mode", "full", or
-    "quantiles" for the alternative distributional outputs the server
-    exposes. When `output_type="quantiles"`, `quantiles` selects the cut
-    points (each in [0, 1]).
-    """
+    """TabPFN regressor backed by a SageMaker endpoint."""
 
     _TASK = "regression"
 

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -20,6 +20,8 @@ and reference that id.
 from __future__ import annotations
 
 import json
+import time
+import uuid
 from typing import Any, Dict, Literal, Optional
 
 import numpy as np
@@ -89,6 +91,11 @@ class _SagemakerBase(BaseEstimator):
         thinking_timeout_s: Optional[float] = None,
         thinking_metric: Optional[str] = None,
         use_kv_cache: bool = False,
+        use_async: bool = False,
+        s3_bucket: Optional[str] = None,
+        s3_prefix: str = "async-io",
+        async_poll_interval_s: float = 2.0,
+        async_timeout_s: float = 60 * 60,
     ):
         self.endpoint_name = endpoint_name
         self.region_name = region_name
@@ -108,6 +115,15 @@ class _SagemakerBase(BaseEstimator):
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.use_kv_cache = use_kv_cache
+        # Async Inference path: required for payloads > 6 MB or compute > 60 s.
+        # When True, requests stage input through S3 and poll the output S3
+        # location SageMaker writes back. The endpoint must be configured with
+        # AsyncInferenceConfig.
+        self.use_async = use_async
+        self.s3_bucket = s3_bucket
+        self.s3_prefix = s3_prefix
+        self.async_poll_interval_s = async_poll_interval_s
+        self.async_timeout_s = async_timeout_s
 
     @property
     def _thinking_active(self) -> bool:
@@ -172,11 +188,26 @@ class _SagemakerBase(BaseEstimator):
         self._cached_client = client
         return client
 
+    def _s3_client(self):
+        client = getattr(self, "_cached_s3", None)
+        if client is not None:
+            return client
+        _require_boto3()
+        if self.boto_session is not None:
+            client = self.boto_session.client("s3")
+        elif self.region_name is not None:
+            client = boto3.client("s3", region_name=self.region_name)
+        else:
+            client = boto3.client("s3")
+        self._cached_s3 = client
+        return client
+
     def __getstate__(self) -> Dict[str, Any]:
         # boto3 clients aren't pickleable. Strip the cache so the estimator
         # stays compatible with sklearn's pickle-based parallel/grid utilities.
         state = self.__dict__.copy()
         state.pop("_cached_client", None)
+        state.pop("_cached_s3", None)
         return state
 
     def fit(self, X: Any, y: Any) -> "_SagemakerBase":
@@ -225,18 +256,77 @@ class _SagemakerBase(BaseEstimator):
             if y_arr.ndim == 1:
                 y_arr = y_arr.reshape(-1, 1)
             body["y_train"] = y_arr.tolist()
-        resp = self._runtime_client().invoke_endpoint(
-            EndpointName=self.endpoint_name,
-            ContentType="application/json",
-            Accept="application/json",
-            Body=json.dumps(body).encode("utf-8"),
-        )
-        # StreamingBody is file-like; json.load avoids buffering the full
-        # response in memory, which matters for output_type="full".
-        payload = json.load(resp["Body"])
+        body_bytes = json.dumps(body).encode("utf-8")
+        if self.use_async:
+            payload = self._invoke_async(body_bytes)
+        else:
+            resp = self._runtime_client().invoke_endpoint(
+                EndpointName=self.endpoint_name,
+                ContentType="application/json",
+                Accept="application/json",
+                Body=body_bytes,
+            )
+            # StreamingBody is file-like; json.load avoids buffering the full
+            # response in memory, which matters for output_type="full".
+            payload = json.load(resp["Body"])
         if self._effective_use_kv_cache:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id
         return payload
+
+    def _invoke_async(self, body_bytes: bytes) -> Dict[str, Any]:
+        """Async Inference path: stage input through S3, invoke_endpoint_async,
+        poll the OutputLocation S3 object. Required for payloads > 6 MB or
+        compute > 60 s; the endpoint must be created with AsyncInferenceConfig.
+        """
+        if not self.s3_bucket:
+            raise RuntimeError(
+                "use_async=True requires `s3_bucket` (writable bucket the "
+                "endpoint's execution role can read from).",
+            )
+        s3 = self._s3_client()
+        inference_id = uuid.uuid4().hex
+        input_key = f"{self.s3_prefix}/inputs/{inference_id}.json"
+        s3.put_object(
+            Bucket=self.s3_bucket,
+            Key=input_key,
+            Body=body_bytes,
+            ContentType="application/json",
+        )
+        resp = self._runtime_client().invoke_endpoint_async(
+            EndpointName=self.endpoint_name,
+            InputLocation=f"s3://{self.s3_bucket}/{input_key}",
+            ContentType="application/json",
+            Accept="application/json",
+            InferenceId=inference_id,
+        )
+        out_bucket, out_key = resp["OutputLocation"].removeprefix("s3://").split("/", 1)
+        fail_location = resp.get("FailureLocation")
+        fail_bucket, fail_key = (None, None)
+        if fail_location:
+            fail_bucket, fail_key = fail_location.removeprefix("s3://").split("/", 1)
+
+        deadline = time.time() + self.async_timeout_s
+        not_found = s3.exceptions.NoSuchKey
+        while time.time() < deadline:
+            try:
+                obj = s3.get_object(Bucket=out_bucket, Key=out_key)
+                return json.load(obj["Body"])
+            except not_found:
+                pass
+            if fail_bucket is not None:
+                try:
+                    f_obj = s3.get_object(Bucket=fail_bucket, Key=fail_key)
+                    detail = f_obj["Body"].read().decode("utf-8", errors="replace")
+                    raise RuntimeError(
+                        f"SageMaker async inference failed for id={inference_id}: {detail}",
+                    )
+                except not_found:
+                    pass
+            time.sleep(self.async_poll_interval_s)
+        raise TimeoutError(
+            f"SageMaker async inference timed out after {self.async_timeout_s}s "
+            f"for id={inference_id}; output never appeared at {resp['OutputLocation']}",
+        )
 
 
 class TabPFNClassifier(_SagemakerBase, ClassifierMixin):

--- a/src/tabpfn_client/sagemaker/estimator.py
+++ b/src/tabpfn_client/sagemaker/estimator.py
@@ -109,6 +109,17 @@ class _SagemakerBase(BaseEstimator):
         self.thinking_metric = thinking_metric
         self.use_kv_cache = use_kv_cache
 
+    @property
+    def _thinking_active(self) -> bool:
+        return self.thinking_mode or self.thinking_effort is not None
+
+    @property
+    def _effective_use_kv_cache(self) -> bool:
+        # Thinking implies caching: without it every predict redoes the
+        # autogluon HPO sweep. The server enforces this too; we mirror it
+        # client-side so the wire body always agrees.
+        return self.use_kv_cache or self._thinking_active
+
     def _build_tabpfn_config(self) -> Dict[str, Any]:
         cfg: Dict[str, Any] = {
             "n_estimators": self.n_estimators,
@@ -118,23 +129,32 @@ class _SagemakerBase(BaseEstimator):
             "inference_precision": self.inference_precision,
             "random_state": self.random_state,
             "inference_config": self.inference_config,
-            "fit_mode": "fit_with_cache" if self.use_kv_cache else "fit_preprocessors",
+            "fit_mode": "fit_with_cache" if self._effective_use_kv_cache else "fit_preprocessors",
         }
         # paper_version is OSS TabPFN-only — server's tagged-union forbids
         # extras. balance_probabilities lives only on ClassifierTabPFNConfig.
+        # thinking_* fields live at the top of the body, not under
+        # tabpfn_config — see `_invoke`.
         if self._TASK == "classification":
             cfg["balance_probabilities"] = self.balance_probabilities
-        if self.thinking_mode or self.thinking_effort is not None:
-            cfg["thinking_mode"] = True
-            if self.thinking_effort is not None:
-                cfg["thinking_effort"] = self.thinking_effort
-            if self.thinking_timeout_s is not None:
-                cfg["thinking_timeout_s"] = self.thinking_timeout_s
-            if self.thinking_metric is not None:
-                cfg["thinking_metric"] = self.thinking_metric
         if self.model_path not in ("auto", "default"):
             cfg["model_path"] = self.model_path
         return cfg
+
+    def _build_thinking_block(self) -> Dict[str, Any]:
+        """Top-level wire fields for thinking-mode. Sibling of
+        `task_config`, mirroring gapi's `FitRequest` shape. Empty when
+        thinking isn't active so callers can splat unconditionally."""
+        if not self._thinking_active:
+            return {}
+        block: Dict[str, Any] = {
+            "thinking_effort": self.thinking_effort if self.thinking_effort is not None else "medium",
+        }
+        if self.thinking_timeout_s is not None:
+            block["thinking_timeout_s"] = self.thinking_timeout_s
+        if self.thinking_metric is not None:
+            block["thinking_metric"] = self.thinking_metric
+        return block
 
     def _runtime_client(self):
         # Cached on the instance: boto3 service-model load + credential
@@ -192,8 +212,9 @@ class _SagemakerBase(BaseEstimator):
                 "predict_params": params,
             },
             "X_test": _to_jsonable(X_test),
+            **self._build_thinking_block(),
         }
-        if self.use_kv_cache and self._cached_model_id is not None:
+        if self._effective_use_kv_cache and self._cached_model_id is not None:
             body["context"] = {"model_id": self._cached_model_id}
         else:
             body["X_train"] = _to_jsonable(self.X_train_)
@@ -213,7 +234,7 @@ class _SagemakerBase(BaseEstimator):
         # StreamingBody is file-like; json.load avoids buffering the full
         # response in memory, which matters for output_type="full".
         payload = json.load(resp["Body"])
-        if self.use_kv_cache:
+        if self._effective_use_kv_cache:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id
         return payload
 


### PR DESCRIPTION
Adds a new `tabpfn_client.sagemaker` submodule providing scikit-learn-style `TabPFNClassifier` and `TabPFNRegressor` that proxy through `boto3.client("sagemaker-runtime").invoke_endpoint` to a TabPFN SageMaker BYOC endpoint 