### PR TITLE
Add eval_metric and tuning_config to client TabPFNClassifier

### DIFF
--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -61,6 +61,22 @@ THINKING_TIMEOUT_MAX_S = 40 * 60
 ThinkingEffort = Literal["medium", "high"]
 _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 
+# Mirrors tabpfn.inference_tuning.ClassifierEvalMetrics in the OSS package.
+_VALID_EVAL_METRICS = frozenset(
+    {"f1", "accuracy", "balanced_accuracy", "roc_auc", "log_loss"}
+)
+# Mirrors the fields of tabpfn.inference_tuning.ClassifierTuningConfig. The
+# server is the source of truth for tuning; we only reject obviously-malformed
+# configs up front so users get a clear error instead of an opaque 4xx.
+_VALID_TUNING_CONFIG_KEYS = frozenset(
+    {
+        "calibrate_temperature",
+        "tune_decision_thresholds",
+        "tuning_holdout_frac",
+        "tuning_n_folds",
+    }
+)
+
 
 class TabPFNModelSelection:
     """Base class for TabPFN model selection and path handling."""
@@ -183,6 +199,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         softmax_temperature: float = 0.9,
         balance_probabilities: bool = False,
         average_before_softmax: bool = False,
+        eval_metric: Optional[str] = None,
+        tuning_config: Optional[Dict] = None,
         ignore_pretraining_limits: bool = True,
         inference_precision: Literal["autocast", "auto"] = "auto",
         random_state: Optional[
@@ -231,6 +249,29 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
              predictive performance when there are many classes or when calibrating the
              model's confidence. This is only applied when predicting during a
              post-processing.
+        eval_metric: str or None, default=None
+            Metric by which predictions will ultimately be evaluated on test data.
+            Setting it lets the server tune the model's predictions for this metric
+            during the fit (probability calibration and decision-threshold tuning on
+            held-out data), controlled by `tuning_config`. On its own this only
+            records the objective; tuning runs only when `tuning_config` is also set.
+            One of: "f1", "accuracy", "balanced_accuracy", "roc_auc", "log_loss".
+            Defaults to "accuracy" server-side when None.
+        tuning_config: dict or None, default=None
+            Settings used to tune the model's predictions for `eval_metric` during
+            the fit. When None (default) no tuning is performed. Recognised keys:
+
+            - "calibrate_temperature" (bool, default False): calibrate the softmax
+              temperature on held-out data.
+            - "tune_decision_thresholds" (bool, default False): tune per-class
+              decision thresholds to optimize `eval_metric`.
+            - "tuning_holdout_frac" ("auto" or float, default "auto"): fraction of
+              the training data held out per split for tuning.
+            - "tuning_n_folds" ("auto" or int, default "auto"): number of
+              cross-validation folds used for tuning.
+
+            Tuning is recommended only for datasets with more than ~500 samples and
+            adds server-side fit cost roughly proportional to `tuning_n_folds`.
         ignore_pretraining_limits: bool, default=True
             Whether to ignore the pre-training limits of the model. The TabPFN models
             have been pre-trained on a specific range of input data. If the input data
@@ -290,6 +331,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.softmax_temperature = softmax_temperature
         self.balance_probabilities = balance_probabilities
         self.average_before_softmax = average_before_softmax
+        self.eval_metric = eval_metric
+        self.tuning_config = tuning_config
         self.ignore_pretraining_limits = ignore_pretraining_limits
         self.inference_precision = inference_precision
         self.random_state = random_state
@@ -328,6 +371,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             self.thinking_metric,
             self.model_path,
         )
+        validate_tuning(self.eval_metric, self.tuning_config)
         X = _clean_text_features(X)
         self._validate_targets_and_classes(y)
 
@@ -822,6 +866,44 @@ def validate_thinking_mode(
             f"model_path={model_path!r}. Either leave model_path at its "
             f"default ('auto') or set it to a v3 model (e.g. 'v3_default')."
         )
+
+
+def validate_tuning(
+    eval_metric: Optional[str],
+    tuning_config: Optional[Dict],
+) -> None:
+    """Validate the post-hoc tuning knobs before forwarding them to the server.
+
+    Tuning itself runs server-side; this only catches obviously-malformed input
+    so users get an actionable error locally instead of an opaque 4xx.
+    """
+    if eval_metric is not None and eval_metric not in _VALID_EVAL_METRICS:
+        raise ValueError(
+            f"eval_metric must be one of {sorted(_VALID_EVAL_METRICS)}, "
+            f"got {eval_metric!r}."
+        )
+
+    if tuning_config is None:
+        return
+
+    if not isinstance(tuning_config, dict):
+        raise ValueError(
+            f"tuning_config must be a dict or None, got {type(tuning_config).__name__}."
+        )
+
+    unknown_keys = set(tuning_config) - _VALID_TUNING_CONFIG_KEYS
+    if unknown_keys:
+        raise ValueError(
+            f"tuning_config contains unknown keys: {sorted(unknown_keys)}. "
+            f"Valid keys are {sorted(_VALID_TUNING_CONFIG_KEYS)}."
+        )
+
+    for bool_key in ("calibrate_temperature", "tune_decision_thresholds"):
+        if bool_key in tuning_config and not isinstance(tuning_config[bool_key], bool):
+            raise ValueError(
+                f"tuning_config[{bool_key!r}] must be a bool, "
+                f"got {type(tuning_config[bool_key]).__name__}."
+            )
 
 
 def validate_train_set(X: np.ndarray, y: Union[np.ndarray, None] = None):

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -474,6 +474,8 @@ class TestTabPFNClassifierInference(unittest.TestCase):
             "inference_config",
             "model_path",
             "balance_probabilities",
+            "eval_metric",
+            "tuning_config",
             "paper_version",
             "thinking_mode",
             "thinking_effort",
@@ -869,6 +871,89 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             tabpfn.fit(X, y_str)
         self.assertIn("exceeds the maximal number of", str(cm.exception))
+
+
+class TestTabPFNClassifierTuning(unittest.TestCase):
+    """eval_metric / tuning_config forwarding and validation."""
+
+    def test_tuning_params_forwarded_to_config(self):
+        """eval_metric and tuning_config reach the server-bound tabpfn_config."""
+        tuning_config = {
+            "calibrate_temperature": True,
+            "tune_decision_thresholds": True,
+        }
+        classifier = TabPFNClassifier(
+            eval_metric="f1",
+            tuning_config=tuning_config,
+        )
+        classifier.fitted_ = True  # Skip fitting
+        classifier.last_fitted_train_set_id = "dummy_uid"
+
+        test_X = np.random.randn(10, 5)
+        with patch.object(InferenceClient, "predict") as mock_predict:
+            mock_predict.return_value = PredictionResult(
+                y_pred={"probas": np.random.rand(10, 2)}, metadata={}
+            )
+            classifier.predict(test_X)
+
+            config_sent = mock_predict.call_args[1]["tabpfn_config"]
+            self.assertEqual(config_sent["eval_metric"], "f1")
+            self.assertEqual(config_sent["tuning_config"], tuning_config)
+
+    def test_tuning_params_default_to_none(self):
+        classifier = TabPFNClassifier()
+        self.assertIsNone(classifier.eval_metric)
+        self.assertIsNone(classifier.tuning_config)
+
+    def test_invalid_eval_metric_raises(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        with self.assertRaises(ValueError) as cm:
+            validate_tuning(eval_metric="rmse", tuning_config=None)
+        self.assertIn("eval_metric must be one of", str(cm.exception))
+
+    def test_valid_eval_metrics_accepted(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        for metric in ("f1", "accuracy", "balanced_accuracy", "roc_auc", "log_loss"):
+            validate_tuning(eval_metric=metric, tuning_config=None)
+
+    def test_unknown_tuning_config_key_raises(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        with self.assertRaises(ValueError) as cm:
+            validate_tuning(eval_metric=None, tuning_config={"calibate_temp": True})
+        self.assertIn("unknown keys", str(cm.exception))
+
+    def test_non_dict_tuning_config_raises(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        with self.assertRaises(ValueError) as cm:
+            validate_tuning(eval_metric=None, tuning_config=["calibrate_temperature"])
+        self.assertIn("must be a dict", str(cm.exception))
+
+    def test_non_bool_flag_raises(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        with self.assertRaises(ValueError) as cm:
+            validate_tuning(
+                eval_metric=None,
+                tuning_config={"calibrate_temperature": "yes"},
+            )
+        self.assertIn("must be a bool", str(cm.exception))
+
+    def test_valid_tuning_config_accepted(self):
+        from tabpfn_client.estimator import validate_tuning
+
+        validate_tuning(
+            eval_metric="f1",
+            tuning_config={
+                "calibrate_temperature": True,
+                "tune_decision_thresholds": False,
+                "tuning_holdout_frac": "auto",
+                "tuning_n_folds": 5,
+            },
+        )
 
 
 class TestTabPFNModelSelection(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds the OSS post-hoc tuning knobs — `eval_metric` and `tuning_config` — to the client `TabPFNClassifier`, so probability calibration and decision-threshold tuning can be driven from the client and executed **server-side** (Option A: thin-client forwarding, no local model/torch involvement).

In the OSS `tabpfn` package these are constructor params on `TabPFNClassifier` (see `src/tabpfn/inference_tuning.py`):
- `eval_metric` — *what* to optimize (`f1`, `accuracy`, `balanced_accuracy`, `roc_auc`, `log_loss`).
- `tuning_config` — *whether/how* to optimize: `calibrate_temperature`, `tune_decision_thresholds`, `tuning_holdout_frac`, `tuning_n_folds`.

Both are pure post-hoc transforms on model outputs (temperature scaling of logits; per-class threshold reweighting of probabilities), and the resulting tuning state (a scalar temperature + an `n_classes` threshold vector) is small — which is exactly why pushing the config to the server and applying it there is the clean fit for the client's stateless architecture.

## Changes

- **`estimator.py`**: add `eval_metric: Optional[str]` and `tuning_config: Optional[Dict]` to `TabPFNClassifier.__init__`, stored as attributes and documented. They auto-forward via the existing `tabpfn_config` dict (free-form `Dict[str, Any]`) on both fit and predict — **no wire-schema change**.
- **`validate_tuning()`**: fast local validation (unknown metric, non-dict config, unknown keys, non-bool flags) mirroring `tabpfn.inference_tuning`'s allowed values, so users get an actionable error instead of an opaque 4xx.
- **Tests**: extend the param-allowlist test; add forwarding + validation coverage.

## Out of scope / follow-ups

- ⚠️ **Server support is a prerequisite.** This PR only forwards the fields; the server must read `eval_metric`/`tuning_config` from `tabpfn_config`, run the holdout tuning during fit, persist the tuning state with the fitted train set, and apply it at predict. Until then these params are no-ops on the wire.
- **Regressor** support (`TuningConfig` base: `calibrate_temperature` etc.) is a separate follow-up; `eval_metric`/threshold tuning are classifier-only in OSS.
- Optional future alignment: share `ClassifierEvalMetrics` / `TuningConfig` definitions via `tabpfn-common-utils` rather than mirroring the allowed-value sets here.

## Test plan

- [x] `pytest tests/unit/test_tabpfn_classifier.py` — 34 passed
- [x] `ruff check` — clean
- [ ] End-to-end against a server build that consumes the new fields (blocked on server work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)