### PR TITLE
Support for running TabPFN on AI Foundry via the client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,49 @@ clf = TabPFNClassifier(
 
 The first `predict*` call after `fit()` runs the fit on the endpoint and can take from tens of seconds up to several minutes depending on `thinking_effort` and data size; the fitted model is cached on the endpoint and subsequent calls are fast. Caching is **required** when thinking is enabled (the client sets `use_kv_cache=True` automatically) — without it every prediction would redo the fit, which would exceed SageMaker's synchronous invoke window. Only `thinking_effort="medium"` is reliable within the real-time endpoint's ~60 s sync window for the *first* call; `"high"` may exceed it and is currently best-effort.
 
+## Azure AI Foundry
+
+If you've deployed TabPFN to an Azure AI Foundry managed online endpoint, you can invoke it through `tabpfn_client.foundry` using the same scikit-learn surface. There is no PriorLabs API token in this path — you authenticate against your own Foundry endpoint with its bearer key, and `predict` calls are billed by Azure rather than against your TabPFN usage allowance.
+
+Point the estimator at your endpoint URL and pass the bearer key:
+
+```python
+from tabpfn_client.foundry import TabPFNClassifier, TabPFNRegressor
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
+
+clf = TabPFNClassifier(
+    endpoint_url="https://<your-endpoint>.<region>.inference.ml.azure.com/predict",
+    api_key="<your-foundry-bearer-token>",
+)
+clf.fit(X_train, y_train)
+clf.predict(X_test)
+clf.predict_proba(X_test)
+```
+
+Notes:
+
+- `endpoint_url` is the full Foundry scoring URL, including the `/predict` path. The bearer key is sent as `Authorization: Bearer <api_key>`.
+- Requests are sent as `application/json`; the Foundry path does not use multipart, so all data travels JSON-encoded.
+
+Set `use_kv_cache=True` if you will call `predict*` more than once on the same training data. The first call ships `X_train` / `y_train` to the endpoint, runs the fit there, and gets back a `model_id`. The client caches that id, and every subsequent call sends only `X_test` plus the id — the server **skips the fit and runs inference only**. That makes follow-up calls dramatically faster on non-trivial training sets, and shrinks the wire payload from O(n_train + n_test) down to O(n_test):
+
+```python
+clf = TabPFNClassifier(
+    endpoint_url="https://<your-endpoint>.<region>.inference.ml.azure.com/predict",
+    api_key="<your-foundry-bearer-token>",
+    use_kv_cache=True,
+)
+clf.fit(X_train, y_train)
+clf.predict(X_test_a)          # first call: fit + predict on the endpoint
+clf.predict_proba(X_test_b)    # cache hit: predict only — much faster
+```
+
+Leave `use_kv_cache=False` (the default) when each call uses a different training set; otherwise the cache is dead weight on the endpoint.
+
 ## Join Our Community
 
 We're building the future of tabular machine learning and would love your involvement! Here's how you can participate and get help:

--- a/src/tabpfn_client/foundry/__init__.py
+++ b/src/tabpfn_client/foundry/__init__.py
@@ -1,0 +1,11 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+#  Licensed under the Apache License, Version 2.0
+"""Azure AI Foundry client for TabPFN.
+
+from tabpfn_client.foundry import TabPFNClassifier, TabPFNRegressor
+"""
+
+from tabpfn_client.foundry.estimator import TabPFNClassifier, TabPFNRegressor
+
+
+__all__ = ["TabPFNClassifier", "TabPFNRegressor"]

--- a/src/tabpfn_client/foundry/estimator.py
+++ b/src/tabpfn_client/foundry/estimator.py
@@ -1,0 +1,235 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+#  Licensed under the Apache License, Version 2.0
+"""scikit-learn estimators for the TabPFN Azure AI Foundry endpoint.
+
+Mirrors the `tabpfn_client.TabPFNClassifier` / `TabPFNRegressor` surface;
+each `predict*` call POSTs to the user-supplied `endpoint_url` (the full
+scoring URL, including the `/predict` path) with a Bearer token. `fit()`
+does not call the endpoint — it just stores `X` / `y` on the estimator.
+The training data is shipped to the endpoint on the next `predict*`
+call, where the actual fit runs.
+
+This client sends requests as `application/json` only (Foundry also
+accepts `multipart/form-data`, but we don't use it here) and does not
+currently support thinking mode.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+
+import httpx
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+from sklearn.utils.validation import check_is_fitted
+
+
+def _to_jsonable(X: Any) -> list:
+    """Coerce numpy / pandas inputs to plain Python lists for JSON."""
+    if isinstance(X, pd.DataFrame):
+        return X.values.tolist()
+    if isinstance(X, pd.Series):
+        return X.tolist()
+    return np.asarray(X).tolist()
+
+
+def _build_request_body(
+    task: str,
+    tabpfn_config: Dict[str, Any],
+    predict_params: Dict[str, Any],
+    X_test: Any,
+    X_train: Optional[Any] = None,
+    y_train: Optional[Any] = None,
+    cached_model_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Assemble a Foundry `/predict` JSON body.
+
+    When `cached_model_id` is provided, the body targets the V3 cache-hit
+    path: `X_train` / `y_train` are omitted and a `context.model_id` is
+    sent instead. Otherwise training data is shipped inline.
+    """
+    body: Dict[str, Any] = {
+        "task_config": {
+            "task": task,
+            "tabpfn_config": tabpfn_config,
+            "predict_params": predict_params,
+        },
+        "x_test": _to_jsonable(X_test),
+    }
+
+    # Build up the KV-cache context if we have a model_id,
+    # otherwise ship the training data
+    if cached_model_id is not None:
+        body["context"] = {"model_id": cached_model_id}
+    else:
+        body["x_train"] = _to_jsonable(X_train)
+
+        # y_train on the wire is 2D (n_samples, 1)
+        y_arr = np.asarray(y_train)
+        if y_arr.ndim == 1:
+            y_arr = y_arr.reshape(-1, 1)
+        body["y_train"] = y_arr.tolist()
+
+    return body
+
+
+class _FoundryBase(BaseEstimator):
+    """Shared HTTP plumbing for the Foundry TabPFN estimators."""
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        api_key: str,
+        task: str = "classification",
+        n_estimators: int = 8,
+        softmax_temperature: float = 0.9,
+        balance_probabilities: bool = False,
+        average_before_softmax: bool = False,
+        ignore_pretraining_limits: bool = True,
+        inference_precision: Literal["autocast", "auto"] = "auto",
+        random_state: Optional[int] = 0,
+        inference_config: Optional[Dict[str, Any]] = None,
+        paper_version: bool = False,
+        use_kv_cache: bool = False,
+        timeout_s: float = 300.0,
+    ):
+        self.endpoint_url = endpoint_url
+        self.api_key = api_key
+        self._task = task
+        self.n_estimators = n_estimators
+        self.softmax_temperature = softmax_temperature
+        self.balance_probabilities = balance_probabilities
+        self.average_before_softmax = average_before_softmax
+        self.ignore_pretraining_limits = ignore_pretraining_limits
+        self.inference_precision = inference_precision
+        self.random_state = random_state
+        self.inference_config = inference_config
+        self.paper_version = paper_version
+        self.use_kv_cache = use_kv_cache
+        self.timeout_s = timeout_s
+
+    def _build_tabpfn_config(self) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {
+            "n_estimators": self.n_estimators,
+            "softmax_temperature": self.softmax_temperature,
+            "average_before_softmax": self.average_before_softmax,
+            "ignore_pretraining_limits": self.ignore_pretraining_limits,
+            "inference_precision": self.inference_precision,
+            "random_state": self.random_state,
+            "inference_config": self.inference_config,
+            "fit_mode": "fit_with_cache" if self.use_kv_cache else "fit_preprocessors",
+        }
+
+        if self._task == "classification":
+            cfg["balance_probabilities"] = self.balance_probabilities
+
+        return cfg
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def fit(self, X: Any, y: Any) -> "_FoundryBase":
+        X_arr = X if isinstance(X, pd.DataFrame) else np.asarray(X)
+        y_arr = y if isinstance(y, (pd.DataFrame, pd.Series)) else np.asarray(y)
+        if X_arr.shape[0] != y_arr.shape[0]:
+            raise ValueError(
+                f"X and y must have the same number of samples; "
+                f"got X={X_arr.shape}, y={y_arr.shape}"
+            )
+
+        self.X_train_ = X_arr
+        self.y_train_ = y_arr
+        self._cached_model_id: Optional[str] = None
+        return self
+
+    def _invoke(
+        self,
+        X_test: Any,
+        output_type: str,
+        predict_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        check_is_fitted(self, ["X_train_", "y_train_"])
+        params: Dict[str, Any] = {"output_type": output_type}
+        if predict_params:
+            params.update(predict_params)
+        body = _build_request_body(
+            task=self._task,
+            tabpfn_config=self._build_tabpfn_config(),
+            predict_params=params,
+            X_test=X_test,
+            X_train=self.X_train_,
+            y_train=self.y_train_,
+            cached_model_id=self._cached_model_id if self.use_kv_cache else None,
+        )
+        resp = httpx.post(
+            self.endpoint_url,
+            json=body,
+            headers=self._headers(),
+            timeout=self.timeout_s,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        if self.use_kv_cache:
+            self._cached_model_id = payload.get("model_id") or self._cached_model_id
+        return payload
+
+
+class TabPFNClassifier(_FoundryBase, ClassifierMixin):
+    """TabPFN classifier backed by an Azure AI Foundry endpoint.
+
+    Example:
+        from tabpfn_client.foundry import TabPFNClassifier
+        clf = TabPFNClassifier(
+            endpoint_url="https://<your-endpoint>.<region>.inference.ml.azure.com/predict",
+            api_key="<your-foundry-bearer-token>",
+        )
+        clf.fit(X_train, y_train)
+        clf.predict(X_test)
+        clf.predict_proba(X_test)
+    """
+
+    def __init__(self, *args: Any, task: str = "classification", **kwargs: Any):
+        super().__init__(*args, task=task, **kwargs)
+
+    def predict(self, X: Any) -> np.ndarray:
+        result = self._invoke(X, output_type="preds")
+        return np.asarray(result["prediction"])
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        result = self._invoke(X, output_type="probas")
+        return np.asarray(result["prediction"])
+
+
+class TabPFNRegressor(_FoundryBase, RegressorMixin):
+    """TabPFN regressor backed by an Azure AI Foundry endpoint.
+
+    Example:
+        from tabpfn_client.foundry import TabPFNRegressor
+        reg = TabPFNRegressor(
+            endpoint_url="https://<your-endpoint>.<region>.inference.ml.azure.com/predict",
+            api_key="<your-foundry-bearer-token>",
+        )
+        reg.fit(X_train, y_train)
+        reg.predict(X_test)
+        reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
+    """
+
+    def __init__(self, *args: Any, task: str = "regression", **kwargs: Any):
+        super().__init__(*args, task=task, **kwargs)
+
+    def predict(
+        self,
+        X: Any,
+        output_type: str = "mean",
+        quantiles: Optional[list] = None,
+    ) -> np.ndarray:
+        predict_params: Dict[str, Any] = {}
+        if quantiles is not None:
+            predict_params["quantiles"] = quantiles
+        result = self._invoke(X, output_type=output_type, predict_params=predict_params)
+        return np.asarray(result["prediction"])

--- a/src/tabpfn_client/foundry/estimator.py
+++ b/src/tabpfn_client/foundry/estimator.py
@@ -133,6 +133,23 @@ class _FoundryBase(BaseEstimator):
             "Accept": "application/json",
         }
 
+    def _http_client(self) -> httpx.Client:
+        # Cache the httpx.Client so repeated predict* calls reuse the TCP /
+        # TLS connection (keep-alive) instead of redoing the handshake on
+        # every request.
+        client = getattr(self, "_cached_client", None)
+        if client is not None:
+            return client
+        client = httpx.Client(timeout=self.timeout_s)
+        self._cached_client = client
+        return client
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # httpx.Client isn't pickleable; strip the cache for sklearn pickling.
+        state = self.__dict__.copy()
+        state.pop("_cached_client", None)
+        return state
+
     def fit(self, X: Any, y: Any) -> "_FoundryBase":
         X_arr = X if isinstance(X, pd.DataFrame) else np.asarray(X)
         y_arr = y if isinstance(y, (pd.DataFrame, pd.Series)) else np.asarray(y)
@@ -145,6 +162,8 @@ class _FoundryBase(BaseEstimator):
         self.X_train_ = X_arr
         self.y_train_ = y_arr
         self._cached_model_id: Optional[str] = None
+        if self._task == "classification":
+            self.classes_ = np.unique(y_arr)
         return self
 
     def _invoke(
@@ -166,11 +185,10 @@ class _FoundryBase(BaseEstimator):
             y_train=self.y_train_,
             cached_model_id=self._cached_model_id if self.use_kv_cache else None,
         )
-        resp = httpx.post(
+        resp = self._http_client().post(
             self.endpoint_url,
             json=body,
             headers=self._headers(),
-            timeout=self.timeout_s,
         )
         resp.raise_for_status()
         payload = resp.json()


### PR DESCRIPTION
### Change Description

Allow running TabPFN-2.5 and TabPFN-3-Plus hosted on AI Foundry using the Client SDK.

