### PR TITLE
chore: release 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.3.2"
+version = "0.3.3"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Bumps the package version 0.3.2 → 0.3.3 so the SageMaker `invocation_timeout_s` passthrough (#333) and everything else on `main` can actually be published. The `0.3.2` number is already taken on PyPI - still open unmerged here https://github.com/PriorLabs/tabpfn-client/pull/314