### PR TITLE
Normalize quantiles predict output to match local tabpfn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.3.3"
+version = "0.4.0"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -788,7 +788,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
 
         output = result.y_pred
         if output_type == "quantiles" and isinstance(output, np.ndarray):
-            output = list(output) if output.ndim == 2 else [output]
+            return list(output) if output.ndim == 2 else [output]
         if output_type == "full":
             try:
                 from tabpfn.regressor import FullSupportBarDistribution  # type: ignore

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -787,6 +787,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self._last_meta = result.metadata
 
         output = result.y_pred
+        if output_type == "quantiles" and isinstance(output, np.ndarray):
+            output = list(output)
         if output_type == "full":
             try:
                 from tabpfn.regressor import FullSupportBarDistribution  # type: ignore

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -788,7 +788,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
 
         output = result.y_pred
         if output_type == "quantiles" and isinstance(output, np.ndarray):
-            output = list(output)
+            output = list(output) if output.ndim == 2 else [output]
         if output_type == "full":
             try:
                 from tabpfn.regressor import FullSupportBarDistribution  # type: ignore

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -581,6 +581,26 @@ class TestTabPFNRegressorInference(unittest.TestCase):
             self.assertIsInstance(arr, np.ndarray)
             self.assertEqual(arr.shape, (20,))
 
+    def test_predict_single_quantile_returns_list_of_one_array(self):
+        """A single quantile may arrive squeezed to 1D; it must still become a
+        list of one (n_samples,) array, matching local tabpfn."""
+        regressor = TabPFNRegressor()
+        regressor.fitted_ = True
+        test_X = np.random.randn(20, 5)
+
+        with patch.object(InferenceClient, "predict") as mock_predict:
+            mock_predict.return_value = PredictionResult(
+                y_pred=np.random.randn(20), metadata={}
+            )
+            output = regressor.predict(
+                test_X, output_type="quantiles", quantiles=[0.5]
+            )
+
+        self.assertIsInstance(output, list)
+        self.assertEqual(len(output), 1)
+        self.assertIsInstance(output[0], np.ndarray)
+        self.assertEqual(output[0].shape, (20,))
+
     def test_predict_full_adds_criterion_with_optional_dependencies(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -559,6 +559,28 @@ class TestTabPFNRegressorInference(unittest.TestCase):
             self.assertEqual(predict_params.output_type, "quantiles")
             self.assertEqual(predict_params.quantiles, quantiles)
 
+    def test_predict_quantiles_returns_list_matching_local_tabpfn(self):
+        """Server returns a stacked (n_quantiles, n_samples) array; predict()
+        normalizes it to a list of per-quantile arrays, matching local tabpfn."""
+        regressor = TabPFNRegressor()
+        regressor.fitted_ = True
+        test_X = np.random.randn(20, 5)
+        quantiles = [0.1, 0.5, 0.9]
+
+        with patch.object(InferenceClient, "predict") as mock_predict:
+            mock_predict.return_value = PredictionResult(
+                y_pred=np.random.randn(len(quantiles), 20), metadata={}
+            )
+            output = regressor.predict(
+                test_X, output_type="quantiles", quantiles=quantiles
+            )
+
+        self.assertIsInstance(output, list)
+        self.assertEqual(len(output), len(quantiles))
+        for arr in output:
+            self.assertIsInstance(arr, np.ndarray)
+            self.assertEqual(arr.shape, (20,))
+
     def test_predict_full_adds_criterion_with_optional_dependencies(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -592,9 +592,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
             mock_predict.return_value = PredictionResult(
                 y_pred=np.random.randn(20), metadata={}
             )
-            output = regressor.predict(
-                test_X, output_type="quantiles", quantiles=[0.5]
-            )
+            output = regressor.predict(test_X, output_type="quantiles", quantiles=[0.5])
 
         self.assertIsInstance(output, list)
         self.assertEqual(len(output), 1)

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -575,7 +575,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
                 test_X, output_type="quantiles", quantiles=quantiles
             )
 
-        self.assertIsInstance(output, list)
+        assert isinstance(output, list)
         self.assertEqual(len(output), len(quantiles))
         for arr in output:
             self.assertIsInstance(arr, np.ndarray)
@@ -594,7 +594,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
             )
             output = regressor.predict(test_X, output_type="quantiles", quantiles=[0.5])
 
-        self.assertIsInstance(output, list)
+        assert isinstance(output, list)
         self.assertEqual(len(output), 1)
         self.assertIsInstance(output[0], np.ndarray)
         self.assertEqual(output[0].shape, (20,))


### PR DESCRIPTION
## Problem

`predict(output_type="quantiles")` returns different container types depending on the backend:

- **Local `tabpfn`**: a `list` of per-quantile 1D arrays, e.g. `[arr(n_samples,), arr(n_samples,), ...]`
- **`tabpfn-client`**: a single stacked 2D `np.ndarray` of shape `(n_quantiles, n_samples)`

Downstream code that consumes quantile predictions has to special-case each backend, and assuming the wrong type silently breaks indexing/shape logic.

Verified against `tabpfn==8.1.0` and `tabpfn-client==0.3.3`.

## Fix

In `TabPFNRegressor.predict`, when `output_type="quantiles"`, convert the server's stacked array into a list of per-quantile arrays so both backends agree on the return type.

## Test

Added `test_predict_quantiles_returns_list_matching_local_tabpfn` asserting the output is a `list` of `n_quantiles` arrays each of shape `(n_samples,)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)