### PR TITLE
Enable fit_with_cache for predictions on API with K/V

### DIFF
--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -53,10 +53,8 @@ class ClassifierPredictParams(BaseModel):
 
 
 class FitMode(str, Enum):
-    LOW_MEMORY = "low_memory"
     FIT_PREPROCESSORS = "fit_preprocessors"
     FIT_WITH_CACHE = "fit_with_cache"
-    BATCHED = "batched"
 
 
 class ClassifierTabPFNConfig(BaseModel):

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -53,11 +53,10 @@ class ClassifierPredictParams(BaseModel):
 
 
 class FitMode(str, Enum):
-    # Only the two values that gapi wires end-to-end. The server-side enum
-    # also has internal `low_memory` / `batched` modes, but those are not
-    # accepted by the public API — see `FitRequest._validate_fit_mode`.
+    LOW_MEMORY = "low_memory"
     FIT_PREPROCESSORS = "fit_preprocessors"
     FIT_WITH_CACHE = "fit_with_cache"
+    BATCHED = "batched"
 
 
 class ClassifierTabPFNConfig(BaseModel):
@@ -126,10 +125,8 @@ class ModelLimit(BaseModel):
     max_classes: int
     max_cols: int
     test_set_max_rows_w_full_regression_output: int
+    predict_row_pairs_budget: int
     test_set_max_cells: int
-    # Optional until all deployed servers send it; estimator.py falls back to
-    # its local default when absent.
-    predict_row_pairs_budget: int | None = None
 
 
 class ModelVersion(str, Enum):
@@ -204,7 +201,6 @@ class DuplicateTestSetErrorResponse(BaseModel):
     message: str
     error_code: str = "DUPLICATE_TEST_SET_UPLOAD"
     trace_id: UUID | None = None
-    detail: str | None = None
     test_set_upload_id: UUID
 
 
@@ -212,7 +208,6 @@ class DuplicateTrainSetErrorResponse(BaseModel):
     message: str
     error_code: str = "DUPLICATE_TRAIN_SET_UPLOAD"
     trace_id: UUID | None = None
-    detail: str | None = None
     train_set_upload_id: UUID
 
 
@@ -268,7 +263,6 @@ class NotFoundErrorResponse(BaseModel):
     message: str
     error_code: str = "NOT_FOUND"
     trace_id: UUID | None = None
-    detail: str | None = None
 
 
 class PredictRequest(BaseModel):

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -53,10 +53,11 @@ class ClassifierPredictParams(BaseModel):
 
 
 class FitMode(str, Enum):
-    LOW_MEMORY = "low_memory"
+    # Only the two values that gapi wires end-to-end. The server-side enum
+    # also has internal `low_memory` / `batched` modes, but those are not
+    # accepted by the public API — see `FitRequest._validate_fit_mode`.
     FIT_PREPROCESSORS = "fit_preprocessors"
     FIT_WITH_CACHE = "fit_with_cache"
-    BATCHED = "batched"
 
 
 class ClassifierTabPFNConfig(BaseModel):

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -125,7 +125,9 @@ class ModelLimit(BaseModel):
     max_classes: int
     max_cols: int
     test_set_max_rows_w_full_regression_output: int
-    predict_row_pairs_budget: int
+    # Optional: older servers don't send this; validate_test_set falls back to
+    # FALLBACK_PREDICT_ROW_PAIRS_BUDGET when absent.
+    predict_row_pairs_budget: int | None = None
     test_set_max_cells: int
 
 

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -52,6 +52,13 @@ class ClassifierPredictParams(BaseModel):
     ) = None
 
 
+class FitMode(str, Enum):
+    LOW_MEMORY = "low_memory"
+    FIT_PREPROCESSORS = "fit_preprocessors"
+    FIT_WITH_CACHE = "fit_with_cache"
+    BATCHED = "batched"
+
+
 class ClassifierTabPFNConfig(BaseModel):
     n_estimators: int | None = None
     categorical_features_indices: list[int] | None = None
@@ -65,6 +72,7 @@ class ClassifierTabPFNConfig(BaseModel):
         Annotated[Literal["autocast", "auto"] | str, Field(union_mode="left_to_right")] | None
     ) = None
     ignore_pretraining_limits: bool | None = None
+    fit_mode: Annotated[FitMode | UnknownEnum, Field(union_mode="left_to_right")] | None = None
     model_path: str | None = None
     balance_probabilities: bool | None = None
 
@@ -161,6 +169,7 @@ class RegressorTabPFNConfig(BaseModel):
         Annotated[Literal["autocast", "auto"] | str, Field(union_mode="left_to_right")] | None
     ) = None
     ignore_pretraining_limits: bool | None = None
+    fit_mode: Annotated[FitMode | UnknownEnum, Field(union_mode="left_to_right")] | None = None
     model_path: str | None = None
 
 
@@ -226,7 +235,7 @@ class FitRequest(BaseModel):
     )
     async_mode: bool | None = Field(
         default=None,
-        description="Submit the fit and return immediately with status=pending; poll GET /tabpfn/fit/{fitted_train_set_id} for the outcome. Defaults to the blocking behaviour.",
+        description="Submit the fit and return immediately with status=pending; poll GET /fit/{fitted_train_set_id} for the outcome. Defaults to the blocking behaviour.",
     )
 
 
@@ -239,6 +248,7 @@ class FitStatusResponse(BaseModel):
     fitted_train_set_id: UUID
     status: Annotated[FitStatus | UnknownEnum, Field(union_mode="left_to_right")]
     error: str | None = None
+    error_code: str | None = None
 
 
 class GetModelLimitsResponse(BaseModel):

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -71,12 +71,10 @@ THINKING_TIMEOUT_MAX_S = 40 * 60
 
 _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 
-# The server's `FitMode` enum also carries internal `low_memory`/`batched`
-# values, but gapi only wires two end-to-end: `fit_preprocessors` (the stateless
-# default) and `fit_with_cache` (persist a server-side KV cache keyed by the
-# returned fitted-train-set id, so later predicts against that id are served
-# from the cache instead of re-fitting). The value is validated server-side by
-# `FitRequest._validate_fit_mode`; the client just forwards it.
+# `FitMode` exposes only the two values gapi wires end-to-end:
+# `fit_preprocessors` (the stateless default) and `fit_with_cache` (persist a
+# server-side KV cache keyed by the returned fitted-train-set id, so later
+# predicts against that id are served from the cache instead of re-fitting).
 
 # Bumped when the shape of the dict produced by `save_model()` changes.
 _MODEL_HANDLE_VERSION = 1

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -87,7 +87,10 @@ _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 
 # Bumped when the shape of the `_ModelHandle` schema changes in a way pydantic
 # validation cannot otherwise catch (e.g. renamed fields, changed semantics).
-_MODEL_HANDLE_VERSION = 1  # Why is it needed?
+_MODEL_HANDLE_VERSION = 1
+
+# Transport params are persisted when saving the model.
+_TRANSPORT_PARAMS = frozenset({"client_options"})
 
 
 class _ModelHandle(BaseModel):
@@ -102,7 +105,7 @@ class _ModelHandle(BaseModel):
     format_version: int
     task: PredictionTask
     model_id: UUID
-    params: dict[str, Any]  # XXX tabpfn_config?
+    params: dict[str, Any]
     classes: list[Any] | None = None  # classification only
 
 
@@ -121,10 +124,11 @@ def _build_model_handle(
 ) -> dict[str, Any] | Path:
     """Shared implementation of `save_model()` for both estimators."""
     check_is_fitted(estimator)
-    params = estimator.get_params(deep=False)  # XXX 2 tabpfn_config?
+    params = estimator.get_params(deep=False)
     # `client_options` is runtime-only (timeouts, auth/trace headers) and not
     # JSON-serializable; drop it so the handle stays portable.
-    params.pop("client_options", None)
+    for param in _TRANSPORT_PARAMS:
+        params.pop(param, None)
     classes: list[Any] | None = None
     if isinstance(estimator, TabPFNClassifier):
         classes = estimator.classes_.tolist()
@@ -135,6 +139,8 @@ def _build_model_handle(
         params=params,
         classes=classes,
     )
+    # NOTE: We always treat None as "unset", therefore we want to exclude None values
+    # to avoid overriding future defaults.
     dumped = handle.model_dump(mode="json", exclude_none=True)
     if path is None:
         return dumped
@@ -171,6 +177,11 @@ def _load_model_handle_for(
         raise ValueError(
             f"Cannot load a {handle.task.value!r} model into {cls.__name__}."
         )
+    if handle.task == PredictionTask.CLASSIFICATION:
+        if handle.classes is None:
+            raise ValueError(
+                f"Classifier handle is missing 'classes'; cannot reconstruct {cls.__name__}."
+            )
     return handle
 
 
@@ -274,7 +285,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     # The server-side fitted-train-set id predictions run against. Written by
     # `fit()` (the id the server returns) and by `load_model()`; absent on
     # unfitted instances, which is what makes `__sklearn_is_fitted__` work.
-    model_id_: UUID
+    model_id_: UUID  # annotation only, no class attribute
 
     def __init__(
         self,
@@ -668,11 +679,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         calling `fit()` again.
         """
         data = _load_model_handle_for(cls, handle, task=PredictionTask.CLASSIFICATION)
-        if data.classes is None:
-            raise ValueError(
-                f"Classifier handle is missing 'classes'; cannot reconstruct {cls.__name__}."
-            )
-        est = cls(**data.params)
+        est = cls(**data.params)  # NOTE: An extra (removed) param will fail-close.
         est.model_id_ = data.model_id
         est.classes_ = np.asarray(data.classes)
         return est

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -80,11 +80,6 @@ FALLBACK_PREDICT_ROW_PAIRS_BUDGET = 250_000 * 1_000_000
 
 _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 
-# `FitMode` exposes only the two values gapi wires end-to-end:
-# `fit_preprocessors` (the stateless default) and `fit_with_cache` (persist a
-# server-side KV cache keyed by the returned fitted-train-set id, so later
-# predicts against that id are served from the cache instead of re-fitting).
-
 # Bumped when the shape of the `_ModelHandle` schema changes in a way pydantic
 # validation cannot otherwise catch (e.g. renamed fields, changed semantics).
 _MODEL_HANDLE_VERSION = 1

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -871,6 +871,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         X_clean = _clean_text_features(X)
 
         if Config.use_server:
+            # NOTE(@trace_id)
             # Create a new sentry trace at every fit, provided that:
             # - The user has not explicitly set a sentry-trace header.
             # - In any case if we're going to refit.
@@ -965,6 +966,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         )
         X_clean = _clean_text_features(X)
 
+        # NOTE(@trace_id)
+        # If this instance was created via `load_model` we assume this is a 
+        # fit-once-predict-many scenario, so we won't try to link all operations
+        # under the same trace. In this case we will let the server create a new trace
+        # for every prediction or use the user-supplied one.
         if (
             "sentry-trace" not in self.client_options.headers
             and self._last_trace_id is not None

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -87,16 +87,7 @@ _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 
 # Bumped when the shape of the `_ModelHandle` schema changes in a way pydantic
 # validation cannot otherwise catch (e.g. renamed fields, changed semantics).
-_MODEL_HANDLE_VERSION = 1
-
-
-class _SavableEstimator(Protocol):
-    """Read-only structural type for the helpers below. Declares only what
-    they actually access on the estimator so the helpers don't need `Any`."""
-
-    model_id: str | UUID | None
-
-    def get_params(self, deep: bool = False) -> dict[str, Any]: ...
+_MODEL_HANDLE_VERSION = 1  # Why is it needed?
 
 
 class _ModelHandle(BaseModel):
@@ -110,11 +101,12 @@ class _ModelHandle(BaseModel):
 
     format_version: int
     task: PredictionTask
-    params: dict[str, Any]
+    params: dict[str, Any]  # tabpfn_config?
     classes: list[Any] | None = None  # classification only
 
 
-def _resolve_train_set_id(estimator: _SavableEstimator) -> UUID | None:
+# XXX 1 fitted_train_set_is_ and model_id?
+def _resolve_train_set_id(estimator: TabPFNClassifier | TabPFNRegressor) -> UUID | None:
     """Resolve the server-side fitted-train-set id an estimator should predict against.
 
     A real `fit()` sets `fitted_train_set_id_` and always wins; otherwise fall
@@ -128,14 +120,13 @@ def _resolve_train_set_id(estimator: _SavableEstimator) -> UUID | None:
     crash `__sklearn_is_fitted__`. The estimator degrades to "not fitted"
     and `predict` surfaces the standard `NotFittedError`.
     """
-    fitted = getattr(estimator, "fitted_train_set_id_", None)
+    fitted = estimator.fitted_train_set_id_
     if fitted is not None:
         return fitted
-    raw = estimator.model_id
-    if raw is None or isinstance(raw, UUID):
-        return raw
+    if estimator.model_id is None:
+        return None
     try:
-        return UUID(str(raw))
+        return UUID(str(estimator.model_id))
     except (ValueError, TypeError):
         return None
 
@@ -149,13 +140,13 @@ def _read_handle_data(source: dict[str, Any] | str | Path) -> dict[str, Any]:
 
 
 def _build_model_handle(
-    estimator: _SavableEstimator,
+    estimator: TabPFNClassifier | TabPFNRegressor,
     task: PredictionTask,
     path: str | Path | None,
 ) -> dict[str, Any] | Path:
     """Shared implementation of `save_model()` for both estimators."""
     check_is_fitted(estimator)
-    params = estimator.get_params(deep=False)
+    params = estimator.get_params(deep=False)  # XXX 2 tabpfn_config?
     # `client_options` is runtime-only (timeouts, auth/trace headers) and not
     # JSON-serializable; drop it so the handle stays portable.
     params.pop("client_options", None)
@@ -163,16 +154,8 @@ def _build_model_handle(
     # `model_id`. Coerce to str for JSON.
     params["model_id"] = str(_resolve_train_set_id(estimator))
     classes: list[Any] | None = None
-    if task is PredictionTask.CLASSIFICATION:
-        classes_attr = getattr(estimator, "classes_", None)
-        if classes_attr is None:
-            # A bare `model_id` classifier (never fit / never load_model'd) has
-            # no class labels to persist; fail clearly instead of AttributeError.
-            raise ValueError(
-                "Cannot save a classifier without `classes_`. Fit it first, or "
-                "reconstruct it via `load_model()`."
-            )
-        classes = classes_attr.tolist()
+    if isinstance(estimator, TabPFNClassifier):
+        classes = estimator.classes_.tolist()
     handle = _ModelHandle(
         format_version=_MODEL_HANDLE_VERSION,
         task=task,
@@ -188,7 +171,7 @@ def _build_model_handle(
 
 
 def _load_model_handle_for(
-    cls: type,
+    cls: type[TabPFNClassifier | TabPFNRegressor],
     source: dict[str, Any] | str | Path,
     task: PredictionTask,
 ) -> _ModelHandle:
@@ -468,6 +451,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.client_options = client_options or ClientOptions()
         self.model_id = model_id
 
+        self.fitted_train_set_id_ = None
         self._last_trace_id = None
         self._last_train_X = None
         self._last_train_y = None
@@ -475,7 +459,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self._last_train_set_description = None
         self._fit_count = 0
 
-    def __sklearn_is_fitted__(self) -> bool:
+    def __sklearn_is_fitted__(self) -> bool:  # XXX 3 prevent loading from instance
         # `fitted_` is a legacy fittedness flag some tests set directly; it is
         # kept as a fallback so those tests keep passing.
         return _resolve_train_set_id(self) is not None or getattr(
@@ -534,7 +518,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             self.fitted_train_set_id_ = cast(UUID, run_task(fit_task, "Fitting"))
             self._last_train_X = X_clean
             self._last_train_y = y
-            self.fitted_ = True
+            self.fitted_ = True  # XXX  4 public?
             self._fit_count += 1
         else:
             raise NotImplementedError(
@@ -715,7 +699,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         return _build_model_handle(self, task=PredictionTask.CLASSIFICATION, path=path)
 
     @classmethod
-    def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNClassifier":
+    def load_model(cls, handle: dict[str, Any] | str | Path) -> TabPFNClassifier:
         """Reconstruct a classifier from a `save_model()` handle (dict or path).
 
         The resulting estimator is already fitted (it references the server-side
@@ -887,6 +871,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.client_options = client_options or ClientOptions()
         self.model_id = model_id
 
+        self.fitted_train_set_id_ = None
         self._last_trace_id = None
         self._last_train_X = None
         self._last_train_y = None
@@ -1139,7 +1124,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         return _build_model_handle(self, task=PredictionTask.REGRESSION, path=path)
 
     @classmethod
-    def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNRegressor":
+    def load_model(cls, handle: dict[str, Any] | str | Path) -> TabPFNRegressor:
         """Reconstruct a regressor from a `save_model()` handle (dict or path).
 
         The resulting estimator is already fitted (it references the server-side

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -91,6 +91,21 @@ def _cast_fitted_id(model_id: str | UUID | None) -> UUID | None:
     return UUID(str(model_id))
 
 
+def _resolve_train_set_id(estimator: Any) -> UUID | None:
+    """Resolve the server-side fitted-train-set id an estimator should predict against.
+
+    A real `fit()` sets `fitted_train_set_id_` and always wins; otherwise fall
+    back to the constructor's `model_id` (the load-by-id path). Keeping this as
+    a resolver instead of syncing state at both mutation sites means `fit()`
+    never has to mutate `self.model_id`, so `get_params()` / `clone()` stay
+    sklearn-correct.
+    """
+    fitted = getattr(estimator, "fitted_train_set_id_", None)
+    if fitted is not None:
+        return fitted
+    return _cast_fitted_id(estimator.model_id)
+
+
 def _read_model_handle(handle: dict[str, Any] | str | Path) -> dict[str, Any]:
     """Accept either an in-memory handle dict or a path to a JSON file
     produced by `save_model()`."""
@@ -112,7 +127,7 @@ def _build_model_handle(
     params.pop("client_options", None)
     # Persist the *effective* id: a real `fit()` supersedes the constructor's
     # `model_id`. Coerce to str for JSON.
-    params["model_id"] = str(estimator._last_fitted_train_set_id)
+    params["model_id"] = str(_resolve_train_set_id(estimator))
     handle: dict[str, Any] = {
         "format_version": _MODEL_HANDLE_VERSION,
         "task": task,
@@ -404,9 +419,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.model_id = model_id
 
         self._last_trace_id = None
-        # Seed the fitted-train-set id from `model_id` so a load-by-id estimator
-        # is immediately usable for predict (see `__sklearn_is_fitted__`).
-        self._last_fitted_train_set_id = _cast_fitted_id(model_id)
         self._last_train_X = None
         self._last_train_y = None
         self._last_meta = {}
@@ -414,11 +426,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self._fit_count = 0
 
     def __sklearn_is_fitted__(self) -> bool:
-        # A real `fit()` sets both `fitted_` and `_last_fitted_train_set_id`;
-        # a load-by-id (via `model_id` / `load_model`) sets only the latter.
-        # Either signal means the estimator can serve predictions.
+        # `fitted_` is a legacy fittedness flag some tests set directly; it is
+        # kept as a fallback so those tests keep passing.
         return (
-            self._last_fitted_train_set_id is not None
+            _resolve_train_set_id(self) is not None
             or getattr(self, "fitted_", False)
         )
 
@@ -471,7 +482,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                     description=description,
                 )
 
-            self._last_fitted_train_set_id = cast(UUID, run_task(fit_task, "Fitting"))
+            self.fitted_train_set_id_ = cast(UUID, run_task(fit_task, "Fitting"))
             self._last_train_X = X_clean
             self._last_train_y = y
             self.fitted_ = True
@@ -513,6 +524,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         # we capture the original user-provided values.
         predict_params = self._get_predict_params(locals())
 
+        # A load-by-id estimator (via `model_id` / `load_model`) can reach
+        # `predict` without ever calling `fit()`, so `init()` (which authorizes
+        # the HTTP client) must run here too. It short-circuits after the first
+        # successful call.
+        init()
         check_is_fitted(self)
 
         tabpfn_config = self._get_tabpfn_config()
@@ -541,7 +557,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 try:
                     return InferenceClient.predict(
                         X_clean,
-                        fitted_train_set_id=cast(UUID, self._last_fitted_train_set_id),
+                        fitted_train_set_id=cast(UUID, _resolve_train_set_id(self)),
                         task_config=task_config,
                         client_options=self.client_options,
                     )
@@ -559,7 +575,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                             "`model_id` / `load_model`). Re-create it by calling "
                             "`fit(X, y)`."
                         ) from exc
-                    self._last_fitted_train_set_id = InferenceClient.fit(
+                    self.fitted_train_set_id_ = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
                         task_config=task_config,
@@ -808,9 +824,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.model_id = model_id
 
         self._last_trace_id = None
-        # Seed the fitted-train-set id from `model_id` so a load-by-id estimator
-        # is immediately usable for predict (see `__sklearn_is_fitted__`).
-        self._last_fitted_train_set_id = _cast_fitted_id(model_id)
         self._last_train_X = None
         self._last_train_y = None
         self._last_meta = {}
@@ -818,11 +831,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self._fit_count = 0
 
     def __sklearn_is_fitted__(self) -> bool:
-        # A real `fit()` sets both `fitted_` and `_last_fitted_train_set_id`;
-        # a load-by-id (via `model_id` / `load_model`) sets only the latter.
-        # Either signal means the estimator can serve predictions.
+        # `fitted_` is a legacy fittedness flag some tests set directly; it is
+        # kept as a fallback so those tests keep passing.
         return (
-            self._last_fitted_train_set_id is not None
+            _resolve_train_set_id(self) is not None
             or getattr(self, "fitted_", False)
         )
 
@@ -876,7 +888,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                     description=description,
                 )
 
-            self._last_fitted_train_set_id = cast(UUID, run_task(fit_task, "Fitting"))
+            self.fitted_train_set_id_ = cast(UUID, run_task(fit_task, "Fitting"))
             self._last_train_X = X_clean
             self._last_train_y = y
             self.fitted_ = True
@@ -923,6 +935,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         # we capture the original user-provided values.
         predict_params = self._get_predict_params(locals())
 
+        # A load-by-id estimator (via `model_id` / `load_model`) can reach
+        # `predict` without ever calling `fit()`, so `init()` (which authorizes
+        # the HTTP client) must run here too. It short-circuits after the first
+        # successful call.
+        init()
         check_is_fitted(self)
 
         tabpfn_config = self._get_tabpfn_config()
@@ -951,7 +968,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                 try:
                     return InferenceClient.predict(
                         X_clean,
-                        fitted_train_set_id=cast(UUID, self._last_fitted_train_set_id),
+                        fitted_train_set_id=cast(UUID, _resolve_train_set_id(self)),
                         task_config=task_config,
                         client_options=self.client_options,
                     )
@@ -969,7 +986,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                             "`model_id` / `load_model`). Re-create it by calling "
                             "`fit(X, y)`."
                         ) from exc
-                    self._last_fitted_train_set_id = InferenceClient.fit(
+                    self.fitted_train_set_id_ = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
                         task_config=task_config,

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Literal, Protocol, cast, overload
+from typing import Any, Callable, Literal, cast, overload
 from typing_extensions import Self
 from uuid import UUID
 
@@ -101,34 +101,9 @@ class _ModelHandle(BaseModel):
 
     format_version: int
     task: PredictionTask
-    params: dict[str, Any]  # tabpfn_config?
+    model_id: UUID
+    params: dict[str, Any]  # XXX tabpfn_config?
     classes: list[Any] | None = None  # classification only
-
-
-# XXX 1 fitted_train_set_is_ and model_id?
-def _resolve_train_set_id(estimator: TabPFNClassifier | TabPFNRegressor) -> UUID | None:
-    """Resolve the server-side fitted-train-set id an estimator should predict against.
-
-    A real `fit()` sets `fitted_train_set_id_` and always wins; otherwise fall
-    back to the constructor's `model_id` (the load-by-id path). Keeping this as
-    a resolver instead of syncing state at both mutation sites means `fit()`
-    never has to mutate `self.model_id`, so `get_params()` / `clone()` stay
-    sklearn-correct.
-
-    Returns None if `model_id` is set but not a valid UUID — sklearn's
-    convention is that `__init__` does no validation, so bad ids must not
-    crash `__sklearn_is_fitted__`. The estimator degrades to "not fitted"
-    and `predict` surfaces the standard `NotFittedError`.
-    """
-    fitted = estimator.fitted_train_set_id_
-    if fitted is not None:
-        return fitted
-    if estimator.model_id is None:
-        return None
-    try:
-        return UUID(str(estimator.model_id))
-    except (ValueError, TypeError):
-        return None
 
 
 def _read_handle_data(source: dict[str, Any] | str | Path) -> dict[str, Any]:
@@ -150,15 +125,13 @@ def _build_model_handle(
     # `client_options` is runtime-only (timeouts, auth/trace headers) and not
     # JSON-serializable; drop it so the handle stays portable.
     params.pop("client_options", None)
-    # Persist the *effective* id: a real `fit()` supersedes the constructor's
-    # `model_id`. Coerce to str for JSON.
-    params["model_id"] = str(_resolve_train_set_id(estimator))
     classes: list[Any] | None = None
     if isinstance(estimator, TabPFNClassifier):
         classes = estimator.classes_.tolist()
     handle = _ModelHandle(
         format_version=_MODEL_HANDLE_VERSION,
         task=task,
+        model_id=estimator.model_id_,
         params=params,
         classes=classes,
     )
@@ -298,6 +271,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         "znskzxi4",
     ]
 
+    # The server-side fitted-train-set id predictions run against. Written by
+    # `fit()` (the id the server returns) and by `load_model()`; absent on
+    # unfitted instances, which is what makes `__sklearn_is_fitted__` work.
+    model_id_: UUID
+
     def __init__(
         self,
         # start: tabpfn_config
@@ -319,7 +297,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         thinking_timeout_s: float | None = None,
         thinking_metric: str | None = None,
         client_options: ClientOptions | None = None,
-        model_id: str | UUID | None = None,
     ):
         """Construct a TabPFN classifier.
 
@@ -418,19 +395,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             predict re-runs the forward pass from the uploaded train set.
             "fit_with_cache" additionally builds and persists a server-side KV
             cache keyed by the resulting fitted-train-set id; later predicts
-            against that id (see `model_id` / `save_model` / `load_model`) are
-            served from the cache instead of re-fitting.
+            against that id (see `save_model` / `load_model`) are served from
+            the cache instead of re-fitting.
         client_options : ClientOptions, default=None
             Client specific options (e.g. timeout, headers).
-        model_id : str, UUID or None, default=None
-            Reference to an already-fitted train set on the server (the id
-            returned by a previous `fit()`, exposed via `save_model()`). When
-            set, the estimator is considered fitted and `predict`/`predict_proba`
-            run against that id without calling `fit()` again — this is what
-            lets a `fit_with_cache` model be reused across processes. A fresh
-            `fit()` call always supersedes it. Note that a classifier
-            constructed this way has no `classes_` unless it is restored via
-            `load_model()`.
         """
         self.model_path = model_path
         self.categorical_features_indices = categorical_features_indices
@@ -449,9 +417,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.client_options = client_options or ClientOptions()
-        self.model_id = model_id
 
-        self.fitted_train_set_id_ = None
         self._last_trace_id = None
         self._last_train_X = None
         self._last_train_y = None
@@ -459,12 +425,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self._last_train_set_description = None
         self._fit_count = 0
 
-    def __sklearn_is_fitted__(self) -> bool:  # XXX 3 prevent loading from instance
-        # `fitted_` is a legacy fittedness flag some tests set directly; it is
-        # kept as a fallback so those tests keep passing.
-        return _resolve_train_set_id(self) is not None or getattr(
-            self, "fitted_", False
-        )
+    def __sklearn_is_fitted__(self) -> bool:
+        return getattr(self, "model_id_", None) is not None
 
     def fit(
         self,
@@ -515,10 +477,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                     description=description,
                 )
 
-            self.fitted_train_set_id_ = cast(UUID, run_task(fit_task, "Fitting"))
+            self.model_id_ = cast(UUID, run_task(fit_task, "Fitting"))
             self._last_train_X = X_clean
             self._last_train_y = y
-            self.fitted_ = True  # XXX  4 public?
             self._fit_count += 1
         else:
             raise NotImplementedError(
@@ -557,9 +518,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         # we capture the original user-provided values.
         predict_params = self._get_predict_params(locals())
 
-        # A load-by-id estimator (via `model_id` / `load_model`) can reach
-        # `predict` without ever calling `fit()`, so `init()` (which authorizes
-        # the HTTP client) must run here too. It short-circuits after the first
+        # A load-by-id estimator (via `load_model`) can reach `predict`
+        # without ever calling `fit()`, so `init()` (which authorizes the
+        # HTTP client) must run here too. It short-circuits after the first
         # successful call.
         init()
         check_is_fitted(self)
@@ -597,7 +558,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 try:
                     return InferenceClient.predict(
                         X_clean,
-                        fitted_train_set_id=cast(UUID, _resolve_train_set_id(self)),
+                        fitted_train_set_id=self.model_id_,
                         task_config=task_config,
                         client_options=self.client_options,
                     )
@@ -605,17 +566,16 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                     last_exc = exc
                     refit_attempts += 1
                     if self._last_train_X is None or self._last_train_y is None:
-                        # A load-by-id estimator (constructed via `model_id` /
-                        # `load_model`) has no training data in memory to rebuild
-                        # from, so we can't transparently recover here.
+                        # A load-by-id estimator (constructed via `load_model`)
+                        # has no training data in memory to rebuild from, so we
+                        # can't transparently recover here.
                         raise RuntimeError(
                             "The referenced fitted model is no longer available "
                             "on the server and this estimator has no in-memory "
                             "training data to refit (it was created via "
-                            "`model_id` / `load_model`). Re-create it by calling "
-                            "`fit(X, y)`."
+                            "`load_model`). Re-create it by calling `fit(X, y)`."
                         ) from exc
-                    self.fitted_train_set_id_ = InferenceClient.fit(
+                    self.model_id_ = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
                         task_config=task_config,
@@ -684,9 +644,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
         """Serialize a portable reference to the fitted (server-side) model.
 
-        The handle captures the server-side fitted-train-set id, the estimator
-        hyperparameters, and the class labels — everything `load_model()` needs
-        to reconstruct an equivalent classifier. No training data leaves the
+        The handle captures the server-side fitted-train-set id (`model_id_`),
+        the estimator hyperparameters, and the class labels — everything
+        `load_model()` needs to reconstruct an equivalent classifier. No
+        training data leaves the
         client; predictions run against the model referenced by the id, so this
         is most useful with `fit_mode="fit_with_cache"`.
 
@@ -712,6 +673,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 f"Classifier handle is missing 'classes'; cannot reconstruct {cls.__name__}."
             )
         est = cls(**data.params)
+        est.model_id_ = data.model_id
         est.classes_ = np.asarray(data.classes)
         return est
 
@@ -738,6 +700,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         "wyl4o83o",
     ]
 
+    # The server-side fitted-train-set id predictions run against. Written by
+    # `fit()` (the id the server returns) and by `load_model()`; absent on
+    # unfitted instances, which is what makes `__sklearn_is_fitted__` work.
+    model_id_: UUID
+
     def __init__(
         self,
         # start: tabpfn_config
@@ -758,7 +725,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         thinking_timeout_s: float | None = None,
         thinking_metric: str | None = None,
         client_options: ClientOptions | None = None,
-        model_id: str | UUID | None = None,
     ):
         """Construct a TabPFN regressor.
 
@@ -841,17 +807,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             predict re-runs the forward pass from the uploaded train set.
             "fit_with_cache" additionally builds and persists a server-side KV
             cache keyed by the resulting fitted-train-set id; later predicts
-            against that id (see `model_id` / `save_model` / `load_model`) are
-            served from the cache instead of re-fitting.
+            against that id (see `save_model` / `load_model`) are served from
+            the cache instead of re-fitting.
         client_options : ClientOptions, default=None
             Client specific options (e.g. timeout, headers).
-        model_id : str, UUID or None, default=None
-            Reference to an already-fitted train set on the server (the id
-            returned by a previous `fit()`, exposed via `save_model()`). When
-            set, the estimator is considered fitted and `predict` runs against
-            that id without calling `fit()` again — this is what lets a
-            `fit_with_cache` model be reused across processes. A fresh `fit()`
-            call always supersedes it.
         """
         self.model_path = model_path
         self.categorical_features_indices = categorical_features_indices
@@ -869,9 +828,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.client_options = client_options or ClientOptions()
-        self.model_id = model_id
 
-        self.fitted_train_set_id_ = None
         self._last_trace_id = None
         self._last_train_X = None
         self._last_train_y = None
@@ -880,11 +837,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self._fit_count = 0
 
     def __sklearn_is_fitted__(self) -> bool:
-        # `fitted_` is a legacy fittedness flag some tests set directly; it is
-        # kept as a fallback so those tests keep passing.
-        return _resolve_train_set_id(self) is not None or getattr(
-            self, "fitted_", False
-        )
+        return getattr(self, "model_id_", None) is not None
 
     def fit(
         self,
@@ -936,10 +889,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                     description=description,
                 )
 
-            self.fitted_train_set_id_ = cast(UUID, run_task(fit_task, "Fitting"))
+            self.model_id_ = cast(UUID, run_task(fit_task, "Fitting"))
             self._last_train_X = X_clean
             self._last_train_y = y
-            self.fitted_ = True
             self._fit_count += 1
         else:
             raise NotImplementedError(
@@ -983,9 +935,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         # we capture the original user-provided values.
         predict_params = self._get_predict_params(locals())
 
-        # A load-by-id estimator (via `model_id` / `load_model`) can reach
-        # `predict` without ever calling `fit()`, so `init()` (which authorizes
-        # the HTTP client) must run here too. It short-circuits after the first
+        # A load-by-id estimator (via `load_model`) can reach `predict`
+        # without ever calling `fit()`, so `init()` (which authorizes the
+        # HTTP client) must run here too. It short-circuits after the first
         # successful call.
         init()
         check_is_fitted(self)
@@ -1023,7 +975,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                 try:
                     return InferenceClient.predict(
                         X_clean,
-                        fitted_train_set_id=cast(UUID, _resolve_train_set_id(self)),
+                        fitted_train_set_id=self.model_id_,
                         task_config=task_config,
                         client_options=self.client_options,
                     )
@@ -1031,17 +983,16 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                     last_exc = exc
                     refit_attempts += 1
                     if self._last_train_X is None or self._last_train_y is None:
-                        # A load-by-id estimator (constructed via `model_id` /
-                        # `load_model`) has no training data in memory to rebuild
-                        # from, so we can't transparently recover here.
+                        # A load-by-id estimator (constructed via `load_model`)
+                        # has no training data in memory to rebuild from, so we
+                        # can't transparently recover here.
                         raise RuntimeError(
                             "The referenced fitted model is no longer available "
                             "on the server and this estimator has no in-memory "
                             "training data to refit (it was created via "
-                            "`model_id` / `load_model`). Re-create it by calling "
-                            "`fit(X, y)`."
+                            "`load_model`). Re-create it by calling `fit(X, y)`."
                         ) from exc
-                    self.fitted_train_set_id_ = InferenceClient.fit(
+                    self.model_id_ = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
                         task_config=task_config,
@@ -1109,8 +1060,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
     def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
         """Serialize a portable reference to the fitted (server-side) model.
 
-        The handle captures the server-side fitted-train-set id and the
-        estimator hyperparameters — everything `load_model()` needs to
+        The handle captures the server-side fitted-train-set id (`model_id_`)
+        and the estimator hyperparameters — everything `load_model()` needs to
         reconstruct an equivalent regressor. No training data leaves the
         client; predictions run against the model referenced by the id, so this
         is most useful with `fit_mode="fit_with_cache"`.
@@ -1131,7 +1082,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         model by id), so it can `predict` without calling `fit()` again.
         """
         data = _load_model_handle_for(cls, handle, task=PredictionTask.REGRESSION)
-        return cls(**data.params)
+        est = cls(**data.params)
+        est.model_id_ = data.model_id
+        return est
 
 
 def _is_thinking_supported_model_path(model_path: str | None) -> bool:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -10,12 +10,13 @@ import time
 from pathlib import Path
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Literal, cast, overload
+from typing import Any, Callable, Literal, Protocol, cast, overload
 from typing_extensions import Self
 from uuid import UUID
 
 import numpy as np
 import pandas as pd
+from pydantic import BaseModel, ValidationError
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils import column_or_1d
 from sklearn.utils.multiclass import check_classification_targets
@@ -34,6 +35,7 @@ from tabpfn_client.utils import model_limit_from_version, model_version_from_pat
 from tabpfn_client.service_wrapper import InferenceClient
 from tabpfn_client.api_models import (
     FitMode,
+    PredictionTask,
     RegressorTabPFNConfig,
     ClassifierTabPFNConfig,
     RegressorPredictParams,
@@ -76,20 +78,36 @@ _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
 # server-side KV cache keyed by the returned fitted-train-set id, so later
 # predicts against that id are served from the cache instead of re-fitting).
 
-# Bumped when the shape of the dict produced by `save_model()` changes.
+# Bumped when the shape of the `_ModelHandle` schema changes in a way pydantic
+# validation cannot otherwise catch (e.g. renamed fields, changed semantics).
 _MODEL_HANDLE_VERSION = 1
 
 
-def _cast_fitted_id(model_id: str | UUID | None) -> UUID | None:
-    """Normalize a user-supplied model id into a UUID (or None)."""
-    if model_id is None:
-        return None
-    if isinstance(model_id, UUID):
-        return model_id
-    return UUID(str(model_id))
+class _SavableEstimator(Protocol):
+    """Read-only structural type for the helpers below. Declares only what
+    they actually access on the estimator so the helpers don't need `Any`."""
+
+    model_id: str | UUID | None
+
+    def get_params(self, deep: bool = False) -> dict[str, Any]: ...
 
 
-def _resolve_train_set_id(estimator: Any) -> UUID | None:
+class _ModelHandle(BaseModel):
+    """Serialized reference to a fitted (server-side) TabPFN model.
+
+    Structural validation (missing keys, wrong types, etc.) is done by
+    pydantic on `load_model`; `format_version` remains as an explicit gate
+    for schema evolution that pydantic cannot see (e.g. semantic changes
+    to fields whose shape hasn't changed).
+    """
+
+    format_version: int
+    task: PredictionTask
+    params: dict[str, Any]
+    classes: list[Any] | None = None  # classification only
+
+
+def _resolve_train_set_id(estimator: _SavableEstimator) -> UUID | None:
     """Resolve the server-side fitted-train-set id an estimator should predict against.
 
     A real `fit()` sets `fitted_train_set_id_` and always wins; otherwise fall
@@ -106,23 +124,26 @@ def _resolve_train_set_id(estimator: Any) -> UUID | None:
     fitted = getattr(estimator, "fitted_train_set_id_", None)
     if fitted is not None:
         return fitted
+    raw = estimator.model_id
+    if raw is None or isinstance(raw, UUID):
+        return raw
     try:
-        return _cast_fitted_id(estimator.model_id)
+        return UUID(str(raw))
     except (ValueError, TypeError):
         return None
 
 
-def _read_model_handle(handle: dict[str, Any] | str | Path) -> dict[str, Any]:
+def _read_handle_data(source: dict[str, Any] | str | Path) -> dict[str, Any]:
     """Accept either an in-memory handle dict or a path to a JSON file
     produced by `save_model()`."""
-    if isinstance(handle, dict):
-        return handle
-    return json.loads(Path(handle).read_text())
+    if isinstance(source, dict):
+        return source
+    return json.loads(Path(source).read_text())
 
 
 def _build_model_handle(
-    estimator: Any,
-    task: Literal["classification", "regression"],
+    estimator: _SavableEstimator,
+    task: PredictionTask,
     path: str | Path | None,
 ) -> dict[str, Any] | Path:
     """Shared implementation of `save_model()` for both estimators."""
@@ -134,46 +155,60 @@ def _build_model_handle(
     # Persist the *effective* id: a real `fit()` supersedes the constructor's
     # `model_id`. Coerce to str for JSON.
     params["model_id"] = str(_resolve_train_set_id(estimator))
-    handle: dict[str, Any] = {
-        "format_version": _MODEL_HANDLE_VERSION,
-        "task": task,
-        "params": params,
-    }
-    if task == "classification":
-        classes = getattr(estimator, "classes_", None)
-        if classes is None:
+    classes: list[Any] | None = None
+    if task is PredictionTask.CLASSIFICATION:
+        classes_attr = getattr(estimator, "classes_", None)
+        if classes_attr is None:
             # A bare `model_id` classifier (never fit / never load_model'd) has
             # no class labels to persist; fail clearly instead of AttributeError.
             raise ValueError(
                 "Cannot save a classifier without `classes_`. Fit it first, or "
                 "reconstruct it via `load_model()`."
             )
-        handle["classes"] = classes.tolist()
+        classes = classes_attr.tolist()
+    handle = _ModelHandle(
+        format_version=_MODEL_HANDLE_VERSION,
+        task=task,
+        params=params,
+        classes=classes,
+    )
+    dumped = handle.model_dump(mode="json", exclude_none=True)
     if path is None:
-        return handle
+        return dumped
     out = Path(path)
-    out.write_text(json.dumps(handle, indent=2))
+    out.write_text(json.dumps(dumped, indent=2))
     return out
 
 
 def _load_model_handle_for(
     cls: type,
-    handle: dict[str, Any] | str | Path,
-    task: Literal["classification", "regression"],
-) -> dict[str, Any]:
-    """Read + validate a `save_model()` handle for the target estimator class."""
-    data = _read_model_handle(handle)
-    version = data.get("format_version")
-    if version != _MODEL_HANDLE_VERSION:
+    source: dict[str, Any] | str | Path,
+    task: PredictionTask,
+) -> _ModelHandle:
+    """Read + validate a `save_model()` handle for the target estimator class.
+
+    Pydantic catches structural problems (missing keys, wrong types, bad
+    enum values); `format_version` is checked separately as an explicit
+    schema-evolution gate; task mismatch is caught last with a clear error.
+    """
+    raw = _read_handle_data(source)
+    try:
+        handle = _ModelHandle.model_validate(raw)
+    except ValidationError as exc:
         raise ValueError(
-            f"Unsupported model handle version {version!r}; "
+            f"Malformed model handle for {cls.__name__} "
+            f"(may be from an unsupported format version): {exc}"
+        ) from exc
+    if handle.format_version != _MODEL_HANDLE_VERSION:
+        raise ValueError(
+            f"Unsupported model handle version {handle.format_version!r}; "
             f"expected {_MODEL_HANDLE_VERSION}."
         )
-    if data.get("task") != task:
+    if handle.task is not task:
         raise ValueError(
-            f"Cannot load a {data.get('task')!r} model into {cls.__name__}."
+            f"Cannot load a {handle.task.value!r} model into {cls.__name__}."
         )
-    return data
+    return handle
 
 
 class TabPFNModelSelection:
@@ -417,7 +452,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.inference_precision = inference_precision
         self.random_state = random_state
         self.inference_config = inference_config
-        self.fit_mode: FitMode | None = fit_mode
+        self.fit_mode = fit_mode
         self.paper_version = paper_version
         self.thinking_mode = thinking_mode
         self.thinking_effort: ThinkingEffort | None = thinking_effort
@@ -663,7 +698,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             If given, the handle is written to this path as JSON and the path
             is returned. If None, the handle dict is returned directly.
         """
-        return _build_model_handle(self, task="classification", path=path)
+        return _build_model_handle(self, task=PredictionTask.CLASSIFICATION, path=path)
 
     @classmethod
     def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNClassifier":
@@ -673,9 +708,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         model by id) and restores `classes_`, so it can `predict` without
         calling `fit()` again.
         """
-        data = _load_model_handle_for(cls, handle, task="classification")
-        est = cls(**data["params"])
-        est.classes_ = np.asarray(data["classes"])
+        data = _load_model_handle_for(cls, handle, task=PredictionTask.CLASSIFICATION)
+        if data.classes is None:
+            raise ValueError(
+                f"Classifier handle is missing 'classes'; cannot reconstruct {cls.__name__}."
+            )
+        est = cls(**data.params)
+        est.classes_ = np.asarray(data.classes)
         return est
 
 
@@ -825,7 +864,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.inference_precision = inference_precision
         self.random_state = random_state
         self.inference_config = inference_config
-        self.fit_mode: FitMode | None = fit_mode
+        self.fit_mode = fit_mode
         self.paper_version = paper_version
         self.thinking_mode = thinking_mode
         self.thinking_effort: ThinkingEffort | None = thinking_effort
@@ -1076,7 +1115,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             If given, the handle is written to this path as JSON and the path
             is returned. If None, the handle dict is returned directly.
         """
-        return _build_model_handle(self, task="regression", path=path)
+        return _build_model_handle(self, task=PredictionTask.REGRESSION, path=path)
 
     @classmethod
     def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNRegressor":
@@ -1085,8 +1124,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         The resulting estimator is already fitted (it references the server-side
         model by id), so it can `predict` without calling `fit()` again.
         """
-        data = _load_model_handle_for(cls, handle, task="regression")
-        return cls(**data["params"])
+        data = _load_model_handle_for(cls, handle, task=PredictionTask.REGRESSION)
+        return cls(**data.params)
 
 
 def _is_thinking_supported_model_path(model_path: str | None) -> bool:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -172,7 +172,9 @@ def _load_model_handle_for(
             f"expected {_MODEL_HANDLE_VERSION}."
         )
     if data.get("task") != task:
-        raise ValueError(f"Cannot load a {data.get('task')!r} model into {cls.__name__}.")
+        raise ValueError(
+            f"Cannot load a {data.get('task')!r} model into {cls.__name__}."
+        )
     return data
 
 
@@ -436,9 +438,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     def __sklearn_is_fitted__(self) -> bool:
         # `fitted_` is a legacy fittedness flag some tests set directly; it is
         # kept as a fallback so those tests keep passing.
-        return (
-            _resolve_train_set_id(self) is not None
-            or getattr(self, "fitted_", False)
+        return _resolve_train_set_id(self) is not None or getattr(
+            self, "fitted_", False
         )
 
     def fit(
@@ -645,6 +646,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 f"{URL_TABPFN_EXTENSIONS_GITHUB_MANY_CLASS_CODE}"
             )
 
+    @overload
+    def save_model(self, path: None = None) -> dict[str, Any]: ...
+    @overload
+    def save_model(self, path: str | Path) -> Path: ...
     def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
         """Serialize a portable reference to the fitted (server-side) model.
 
@@ -841,9 +846,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
     def __sklearn_is_fitted__(self) -> bool:
         # `fitted_` is a legacy fittedness flag some tests set directly; it is
         # kept as a fallback so those tests keep passing.
-        return (
-            _resolve_train_set_id(self) is not None
-            or getattr(self, "fitted_", False)
+        return _resolve_train_set_id(self) is not None or getattr(
+            self, "fitted_", False
         )
 
     def fit(
@@ -1055,6 +1059,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         if sum(pd.isnull(y_)) > 0:
             raise ValueError("Input y contains NaN.")
 
+    @overload
+    def save_model(self, path: None = None) -> dict[str, Any]: ...
+    @overload
+    def save_model(self, path: str | Path) -> Path: ...
     def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
         """Serialize a portable reference to the fitted (server-side) model.
 

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -99,11 +99,19 @@ def _resolve_train_set_id(estimator: Any) -> UUID | None:
     a resolver instead of syncing state at both mutation sites means `fit()`
     never has to mutate `self.model_id`, so `get_params()` / `clone()` stay
     sklearn-correct.
+
+    Returns None if `model_id` is set but not a valid UUID — sklearn's
+    convention is that `__init__` does no validation, so bad ids must not
+    crash `__sklearn_is_fitted__`. The estimator degrades to "not fitted"
+    and `predict` surfaces the standard `NotFittedError`.
     """
     fitted = getattr(estimator, "fitted_train_set_id_", None)
     if fitted is not None:
         return fitted
-    return _cast_fitted_id(estimator.model_id)
+    try:
+        return _cast_fitted_id(estimator.model_id)
+    except (ValueError, TypeError):
+        return None
 
 
 def _read_model_handle(handle: dict[str, Any] | str | Path) -> dict[str, Any]:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 import time
+from pathlib import Path
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Literal, cast, overload
@@ -31,6 +33,7 @@ from tabpfn_client.api_models import ModelVersion
 from tabpfn_client.utils import model_limit_from_version, model_version_from_path
 from tabpfn_client.service_wrapper import InferenceClient
 from tabpfn_client.api_models import (
+    FitMode,
     RegressorTabPFNConfig,
     ClassifierTabPFNConfig,
     RegressorPredictParams,
@@ -67,6 +70,87 @@ _AUTO_MODEL_PATH_ALIASES: frozenset[str | None] = frozenset({None, "auto", "defa
 THINKING_TIMEOUT_MAX_S = 40 * 60
 
 _VALID_THINKING_EFFORT_LEVELS = frozenset({"medium", "high"})
+
+# The server's `FitMode` enum also carries internal `low_memory`/`batched`
+# values, but gapi only wires two end-to-end: `fit_preprocessors` (the stateless
+# default) and `fit_with_cache` (persist a server-side KV cache keyed by the
+# returned fitted-train-set id, so later predicts against that id are served
+# from the cache instead of re-fitting). The value is validated server-side by
+# `FitRequest._validate_fit_mode`; the client just forwards it.
+
+# Bumped when the shape of the dict produced by `save_model()` changes.
+_MODEL_HANDLE_VERSION = 1
+
+
+def _cast_fitted_id(model_id: str | UUID | None) -> UUID | None:
+    """Normalize a user-supplied model id into a UUID (or None)."""
+    if model_id is None:
+        return None
+    if isinstance(model_id, UUID):
+        return model_id
+    return UUID(str(model_id))
+
+
+def _read_model_handle(handle: dict[str, Any] | str | Path) -> dict[str, Any]:
+    """Accept either an in-memory handle dict or a path to a JSON file
+    produced by `save_model()`."""
+    if isinstance(handle, dict):
+        return handle
+    return json.loads(Path(handle).read_text())
+
+
+def _build_model_handle(
+    estimator: Any,
+    task: Literal["classification", "regression"],
+    path: str | Path | None,
+) -> dict[str, Any] | Path:
+    """Shared implementation of `save_model()` for both estimators."""
+    check_is_fitted(estimator)
+    params = estimator.get_params(deep=False)
+    # `client_options` is runtime-only (timeouts, auth/trace headers) and not
+    # JSON-serializable; drop it so the handle stays portable.
+    params.pop("client_options", None)
+    # Persist the *effective* id: a real `fit()` supersedes the constructor's
+    # `model_id`. Coerce to str for JSON.
+    params["model_id"] = str(estimator._last_fitted_train_set_id)
+    handle: dict[str, Any] = {
+        "format_version": _MODEL_HANDLE_VERSION,
+        "task": task,
+        "params": params,
+    }
+    if task == "classification":
+        classes = getattr(estimator, "classes_", None)
+        if classes is None:
+            # A bare `model_id` classifier (never fit / never load_model'd) has
+            # no class labels to persist; fail clearly instead of AttributeError.
+            raise ValueError(
+                "Cannot save a classifier without `classes_`. Fit it first, or "
+                "reconstruct it via `load_model()`."
+            )
+        handle["classes"] = classes.tolist()
+    if path is None:
+        return handle
+    out = Path(path)
+    out.write_text(json.dumps(handle, indent=2))
+    return out
+
+
+def _load_model_handle_for(
+    cls: type,
+    handle: dict[str, Any] | str | Path,
+    task: Literal["classification", "regression"],
+) -> dict[str, Any]:
+    """Read + validate a `save_model()` handle for the target estimator class."""
+    data = _read_model_handle(handle)
+    version = data.get("format_version")
+    if version != _MODEL_HANDLE_VERSION:
+        raise ValueError(
+            f"Unsupported model handle version {version!r}; "
+            f"expected {_MODEL_HANDLE_VERSION}."
+        )
+    if data.get("task") != task:
+        raise ValueError(f"Cannot load a {data.get('task')!r} model into {cls.__name__}.")
+    return data
 
 
 class TabPFNModelSelection:
@@ -179,6 +263,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         random_state: int | None = 0,
         inference_config: dict[str, Any] | None = None,
         categorical_features_indices: list[int] | None = None,
+        fit_mode: FitMode | None = None,
         # end: tabpfn_config
         paper_version: bool = False,
         thinking_mode: bool = False,
@@ -186,6 +271,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         thinking_timeout_s: float | None = None,
         thinking_metric: str | None = None,
         client_options: ClientOptions | None = None,
+        model_id: str | UUID | None = None,
     ):
         """Construct a TabPFN classifier.
 
@@ -277,8 +363,26 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 "roc_auc_ovr_micro", "roc_auc_ovr_weighted".
 
             Aliases "acc", "nll", "pac_score" are also accepted.
+        fit_mode: {"fit_preprocessors", "fit_with_cache"} or None, default=None
+            Controls what the server persists at fit time. None defers to the
+            server default, which is "fit_preprocessors".
+            "fit_preprocessors" fits only the preprocessing state, so every
+            predict re-runs the forward pass from the uploaded train set.
+            "fit_with_cache" additionally builds and persists a server-side KV
+            cache keyed by the resulting fitted-train-set id; later predicts
+            against that id (see `model_id` / `save_model` / `load_model`) are
+            served from the cache instead of re-fitting.
         client_options : ClientOptions, default=None
             Client specific options (e.g. timeout, headers).
+        model_id : str, UUID or None, default=None
+            Reference to an already-fitted train set on the server (the id
+            returned by a previous `fit()`, exposed via `save_model()`). When
+            set, the estimator is considered fitted and `predict`/`predict_proba`
+            run against that id without calling `fit()` again — this is what
+            lets a `fit_with_cache` model be reused across processes. A fresh
+            `fit()` call always supersedes it. Note that a classifier
+            constructed this way has no `classes_` unless it is restored via
+            `load_model()`.
         """
         self.model_path = model_path
         self.categorical_features_indices = categorical_features_indices
@@ -290,20 +394,33 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         self.inference_precision = inference_precision
         self.random_state = random_state
         self.inference_config = inference_config
+        self.fit_mode: FitMode | None = fit_mode
         self.paper_version = paper_version
         self.thinking_mode = thinking_mode
         self.thinking_effort: ThinkingEffort | None = thinking_effort
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.client_options = client_options or ClientOptions()
+        self.model_id = model_id
 
         self._last_trace_id = None
-        self._last_fitted_train_set_id = None
+        # Seed the fitted-train-set id from `model_id` so a load-by-id estimator
+        # is immediately usable for predict (see `__sklearn_is_fitted__`).
+        self._last_fitted_train_set_id = _cast_fitted_id(model_id)
         self._last_train_X = None
         self._last_train_y = None
         self._last_meta = {}
         self._last_train_set_description = None
         self._fit_count = 0
+
+    def __sklearn_is_fitted__(self) -> bool:
+        # A real `fit()` sets both `fitted_` and `_last_fitted_train_set_id`;
+        # a load-by-id (via `model_id` / `load_model`) sets only the latter.
+        # Either signal means the estimator can serve predictions.
+        return (
+            self._last_fitted_train_set_id is not None
+            or getattr(self, "fitted_", False)
+        )
 
     def fit(
         self,
@@ -431,6 +548,17 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 except NeedsRefittingError as exc:
                     last_exc = exc
                     refit_attempts += 1
+                    if self._last_train_X is None or self._last_train_y is None:
+                        # A load-by-id estimator (constructed via `model_id` /
+                        # `load_model`) has no training data in memory to rebuild
+                        # from, so we can't transparently recover here.
+                        raise RuntimeError(
+                            "The referenced fitted model is no longer available "
+                            "on the server and this estimator has no in-memory "
+                            "training data to refit (it was created via "
+                            "`model_id` / `load_model`). Re-create it by calling "
+                            "`fit(X, y)`."
+                        ) from exc
                     self._last_fitted_train_set_id = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
@@ -493,6 +621,36 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
                 f"{URL_TABPFN_EXTENSIONS_GITHUB_MANY_CLASS_CODE}"
             )
 
+    def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
+        """Serialize a portable reference to the fitted (server-side) model.
+
+        The handle captures the server-side fitted-train-set id, the estimator
+        hyperparameters, and the class labels — everything `load_model()` needs
+        to reconstruct an equivalent classifier. No training data leaves the
+        client; predictions run against the model referenced by the id, so this
+        is most useful with `fit_mode="fit_with_cache"`.
+
+        Parameters
+        ----------
+        path : str, Path or None, default=None
+            If given, the handle is written to this path as JSON and the path
+            is returned. If None, the handle dict is returned directly.
+        """
+        return _build_model_handle(self, task="classification", path=path)
+
+    @classmethod
+    def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNClassifier":
+        """Reconstruct a classifier from a `save_model()` handle (dict or path).
+
+        The resulting estimator is already fitted (it references the server-side
+        model by id) and restores `classes_`, so it can `predict` without
+        calling `fit()` again.
+        """
+        data = _load_model_handle_for(cls, handle, task="classification")
+        est = cls(**data["params"])
+        est.classes_ = np.asarray(data["classes"])
+        return est
+
 
 class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
@@ -528,6 +686,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         random_state: int | None = 0,
         inference_config: dict[str, Any] | None = None,
         categorical_features_indices: list[int] | None = None,
+        fit_mode: FitMode | None = None,
         # end: tabpfn_config
         paper_version: bool = False,
         thinking_mode: bool = False,
@@ -535,6 +694,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         thinking_timeout_s: float | None = None,
         thinking_metric: str | None = None,
         client_options: ClientOptions | None = None,
+        model_id: str | UUID | None = None,
     ):
         """Construct a TabPFN regressor.
 
@@ -610,8 +770,24 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
 
             Aliases "mse", "rmse", "mae", "mape", "smape" are also
             accepted.
+        fit_mode: {"fit_preprocessors", "fit_with_cache"} or None, default=None
+            Controls what the server persists at fit time. None defers to the
+            server default, which is "fit_preprocessors".
+            "fit_preprocessors" fits only the preprocessing state, so every
+            predict re-runs the forward pass from the uploaded train set.
+            "fit_with_cache" additionally builds and persists a server-side KV
+            cache keyed by the resulting fitted-train-set id; later predicts
+            against that id (see `model_id` / `save_model` / `load_model`) are
+            served from the cache instead of re-fitting.
         client_options : ClientOptions, default=None
             Client specific options (e.g. timeout, headers).
+        model_id : str, UUID or None, default=None
+            Reference to an already-fitted train set on the server (the id
+            returned by a previous `fit()`, exposed via `save_model()`). When
+            set, the estimator is considered fitted and `predict` runs against
+            that id without calling `fit()` again — this is what lets a
+            `fit_with_cache` model be reused across processes. A fresh `fit()`
+            call always supersedes it.
         """
         self.model_path = model_path
         self.categorical_features_indices = categorical_features_indices
@@ -622,20 +798,33 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         self.inference_precision = inference_precision
         self.random_state = random_state
         self.inference_config = inference_config
+        self.fit_mode: FitMode | None = fit_mode
         self.paper_version = paper_version
         self.thinking_mode = thinking_mode
         self.thinking_effort: ThinkingEffort | None = thinking_effort
         self.thinking_timeout_s = thinking_timeout_s
         self.thinking_metric = thinking_metric
         self.client_options = client_options or ClientOptions()
+        self.model_id = model_id
 
         self._last_trace_id = None
-        self._last_fitted_train_set_id = None
+        # Seed the fitted-train-set id from `model_id` so a load-by-id estimator
+        # is immediately usable for predict (see `__sklearn_is_fitted__`).
+        self._last_fitted_train_set_id = _cast_fitted_id(model_id)
         self._last_train_X = None
         self._last_train_y = None
         self._last_meta = {}
         self._last_train_set_description = None
         self._fit_count = 0
+
+    def __sklearn_is_fitted__(self) -> bool:
+        # A real `fit()` sets both `fitted_` and `_last_fitted_train_set_id`;
+        # a load-by-id (via `model_id` / `load_model`) sets only the latter.
+        # Either signal means the estimator can serve predictions.
+        return (
+            self._last_fitted_train_set_id is not None
+            or getattr(self, "fitted_", False)
+        )
 
     def fit(
         self,
@@ -769,6 +958,17 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
                 except NeedsRefittingError as exc:
                     last_exc = exc
                     refit_attempts += 1
+                    if self._last_train_X is None or self._last_train_y is None:
+                        # A load-by-id estimator (constructed via `model_id` /
+                        # `load_model`) has no training data in memory to rebuild
+                        # from, so we can't transparently recover here.
+                        raise RuntimeError(
+                            "The referenced fitted model is no longer available "
+                            "on the server and this estimator has no in-memory "
+                            "training data to refit (it was created via "
+                            "`model_id` / `load_model`). Re-create it by calling "
+                            "`fit(X, y)`."
+                        ) from exc
                     self._last_fitted_train_set_id = InferenceClient.fit(
                         self._last_train_X,
                         self._last_train_y,
@@ -829,6 +1029,33 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         y_ = column_or_1d(y, warn=True)
         if sum(pd.isnull(y_)) > 0:
             raise ValueError("Input y contains NaN.")
+
+    def save_model(self, path: str | Path | None = None) -> dict[str, Any] | Path:
+        """Serialize a portable reference to the fitted (server-side) model.
+
+        The handle captures the server-side fitted-train-set id and the
+        estimator hyperparameters — everything `load_model()` needs to
+        reconstruct an equivalent regressor. No training data leaves the
+        client; predictions run against the model referenced by the id, so this
+        is most useful with `fit_mode="fit_with_cache"`.
+
+        Parameters
+        ----------
+        path : str, Path or None, default=None
+            If given, the handle is written to this path as JSON and the path
+            is returned. If None, the handle dict is returned directly.
+        """
+        return _build_model_handle(self, task="regression", path=path)
+
+    @classmethod
+    def load_model(cls, handle: dict[str, Any] | str | Path) -> "TabPFNRegressor":
+        """Reconstruct a regressor from a `save_model()` handle (dict or path).
+
+        The resulting estimator is already fitted (it references the server-side
+        model by id), so it can `predict` without calling `fit()` again.
+        """
+        data = _load_model_handle_for(cls, handle, task="regression")
+        return cls(**data["params"])
 
 
 def _is_thinking_supported_model_path(model_path: str | None) -> bool:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -967,7 +967,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
         X_clean = _clean_text_features(X)
 
         # NOTE(@trace_id)
-        # If this instance was created via `load_model` we assume this is a 
+        # If this instance was created via `load_model` we assume this is a
         # fit-once-predict-many scenario, so we won't try to link all operations
         # under the same trace. In this case we will let the server create a new trace
         # for every prediction or use the user-supplied one.

--- a/tests/unit/test_fit_mode_and_model_id.py
+++ b/tests/unit/test_fit_mode_and_model_id.py
@@ -18,7 +18,11 @@ from uuid import UUID
 import numpy as np
 
 from tabpfn_client.client import NeedsRefittingError, PredictionResult, ServiceClient
-from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
+from tabpfn_client.estimator import (
+    TabPFNClassifier,
+    TabPFNRegressor,
+    _resolve_train_set_id,
+)
 from tabpfn_client.service_wrapper import InferenceClient
 
 _MODEL_ID = "00000000-0000-0000-0000-000000000abc"
@@ -65,7 +69,7 @@ class TestModelIdConstructor(unittest.TestCase):
         for Est in (TabPFNClassifier, TabPFNRegressor):
             est = Est(model_id=_MODEL_ID)
             self.assertTrue(est.__sklearn_is_fitted__(), Est.__name__)
-            self.assertEqual(est._last_fitted_train_set_id, UUID(_MODEL_ID))
+            self.assertEqual(_resolve_train_set_id(est), UUID(_MODEL_ID))
             self.assertFalse(Est().__sklearn_is_fitted__(), Est.__name__)
 
     def test_predict_uses_model_id_without_fitting(self):
@@ -83,7 +87,7 @@ class TestModelIdConstructor(unittest.TestCase):
 
     def test_model_id_accepts_uuid_and_str(self):
         self.assertEqual(
-            TabPFNRegressor(model_id=UUID(_MODEL_ID))._last_fitted_train_set_id,
+            _resolve_train_set_id(TabPFNRegressor(model_id=UUID(_MODEL_ID))),
             UUID(_MODEL_ID),
         )
 
@@ -98,7 +102,7 @@ class TestSaveLoadModel(unittest.TestCase):
 
         loaded = TabPFNRegressor.load_model(handle)
         self.assertTrue(loaded.__sklearn_is_fitted__())
-        self.assertEqual(loaded._last_fitted_train_set_id, UUID(_MODEL_ID))
+        self.assertEqual(_resolve_train_set_id(loaded), UUID(_MODEL_ID))
         self.assertEqual(loaded.get_params()["n_estimators"], 4)
 
     def test_classifier_round_trip_restores_classes(self):
@@ -119,14 +123,14 @@ class TestSaveLoadModel(unittest.TestCase):
             self.assertEqual(Path(returned), path)
             self.assertTrue(path.exists())
             loaded = TabPFNRegressor.load_model(path)
-        self.assertEqual(loaded._last_fitted_train_set_id, UUID(_MODEL_ID))
+        self.assertEqual(_resolve_train_set_id(loaded), UUID(_MODEL_ID))
 
     def test_effective_id_beats_constructor_model_id(self):
         # A real fit supersedes the constructor's model_id; save_model must
         # persist the effective (post-fit) id, not the original.
         reg = TabPFNRegressor(model_id=_MODEL_ID)
         new_id = "00000000-0000-0000-0000-000000000fff"
-        reg._last_fitted_train_set_id = UUID(new_id)
+        reg.fitted_train_set_id_ = UUID(new_id)
         self.assertEqual(reg.save_model()["params"]["model_id"], new_id)
 
     def test_load_model_task_mismatch_raises(self):
@@ -168,6 +172,42 @@ class TestRefitGuard(unittest.TestCase):
                         reg.predict(np.random.randn(4, 3))
         self.assertIn("no in-memory", str(ctx.exception).lower())
         mock_fit.assert_not_called()
+
+
+class TestSklearnCompatibility(unittest.TestCase):
+    def test_clone_preserves_model_id_and_stays_fitted(self):
+        # `clone` calls `get_params()` and re-instantiates. `model_id` is a
+        # constructor param, so the clone must keep it (and thus still be
+        # considered fitted for the load-by-id path) — this covers the
+        # get_params/clone desync surfaced by cursor.
+        from sklearn.base import clone
+
+        from typing import Any, cast as _cast
+
+        for Est in (TabPFNClassifier, TabPFNRegressor):
+            original = Est(model_id=_MODEL_ID)
+            # `clone`'s overloaded return over a `type[C] | type[R]` union
+            # confuses pyright; runtime type is Est, but we cast to Any to
+            # avoid re-typing at every call site below.
+            cloned = _cast(Any, clone(original))
+            self.assertEqual(cloned.get_params()["model_id"], _MODEL_ID, Est.__name__)
+            self.assertEqual(
+                _resolve_train_set_id(cloned), UUID(_MODEL_ID), Est.__name__
+            )
+            self.assertTrue(cloned.__sklearn_is_fitted__(), Est.__name__)
+
+    def test_predict_triggers_init_from_cold_state(self):
+        # A fresh process that only calls `load_model(...).predict(...)` never
+        # touches `fit()`, so `_predict` itself must call `init()` to authorize
+        # the HTTP client — otherwise the main cross-process reuse path 401s.
+        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        with patch("tabpfn_client.estimator.init") as mock_init:
+            with patch.object(ServiceClient, "get_model_limits", return_value=None):
+                with patch.object(
+                    InferenceClient, "predict", return_value=_regressor_prediction()
+                ):
+                    reg.predict(np.random.randn(4, 3))
+        mock_init.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_fit_mode_and_model_id.py
+++ b/tests/unit/test_fit_mode_and_model_id.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 import numpy as np
 
+from tabpfn_client.api_models import FitMode
 from tabpfn_client.client import NeedsRefittingError, PredictionResult, ServiceClient
 from tabpfn_client.estimator import (
     TabPFNClassifier,
@@ -32,10 +33,6 @@ def _regressor_prediction() -> PredictionResult:
     return PredictionResult(y_pred={"mean": np.zeros(4)}, metadata={})
 
 
-def _classifier_prediction() -> PredictionResult:
-    return PredictionResult(y_pred=np.zeros(4), metadata={})
-
-
 class TestFitMode(unittest.TestCase):
     def test_default_omits_fit_mode_on_wire(self):
         # Default is None, so nothing is sent and the server applies its own
@@ -48,12 +45,12 @@ class TestFitMode(unittest.TestCase):
 
     def test_fit_with_cache_reaches_wire_config(self):
         for Est in (TabPFNClassifier, TabPFNRegressor):
-            cfg = Est(fit_mode="fit_with_cache")._get_tabpfn_config()
+            cfg = Est(fit_mode=FitMode.FIT_WITH_CACHE)._get_tabpfn_config()
             dumped = cfg.model_dump(mode="json", exclude_none=True)
             self.assertEqual(dumped.get("fit_mode"), "fit_with_cache", Est.__name__)
 
     def test_fit_mode_forwarded_on_predict_task_config(self):
-        reg = TabPFNRegressor(fit_mode="fit_with_cache", model_id=_MODEL_ID)
+        reg = TabPFNRegressor(fit_mode=FitMode.FIT_WITH_CACHE, model_id=_MODEL_ID)
         with patch("tabpfn_client.estimator.init"):
             with patch.object(ServiceClient, "get_model_limits", return_value=None):
                 with patch.object(

--- a/tests/unit/test_fit_mode_and_model_id.py
+++ b/tests/unit/test_fit_mode_and_model_id.py
@@ -54,11 +54,12 @@ class TestFitMode(unittest.TestCase):
 
     def test_fit_mode_forwarded_on_predict_task_config(self):
         reg = TabPFNRegressor(fit_mode="fit_with_cache", model_id=_MODEL_ID)
-        with patch.object(ServiceClient, "get_model_limits", return_value=None):
-            with patch.object(
-                InferenceClient, "predict", return_value=_regressor_prediction()
-            ) as mock_predict:
-                reg.predict(np.random.randn(4, 3))
+        with patch("tabpfn_client.estimator.init"):
+            with patch.object(ServiceClient, "get_model_limits", return_value=None):
+                with patch.object(
+                    InferenceClient, "predict", return_value=_regressor_prediction()
+                ) as mock_predict:
+                    reg.predict(np.random.randn(4, 3))
         task_config = mock_predict.call_args[1]["task_config"]
         dumped = task_config.tabpfn_config.model_dump(mode="json", exclude_none=True)
         self.assertEqual(dumped.get("fit_mode"), "fit_with_cache")
@@ -74,12 +75,13 @@ class TestModelIdConstructor(unittest.TestCase):
 
     def test_predict_uses_model_id_without_fitting(self):
         reg = TabPFNRegressor(model_id=_MODEL_ID)
-        with patch.object(ServiceClient, "get_model_limits", return_value=None):
-            with patch.object(InferenceClient, "fit") as mock_fit:
-                with patch.object(
-                    InferenceClient, "predict", return_value=_regressor_prediction()
-                ) as mock_predict:
-                    reg.predict(np.random.randn(4, 3))
+        with patch("tabpfn_client.estimator.init"):
+            with patch.object(ServiceClient, "get_model_limits", return_value=None):
+                with patch.object(InferenceClient, "fit") as mock_fit:
+                    with patch.object(
+                        InferenceClient, "predict", return_value=_regressor_prediction()
+                    ) as mock_predict:
+                        reg.predict(np.random.randn(4, 3))
         mock_fit.assert_not_called()
         self.assertEqual(
             mock_predict.call_args[1]["fitted_train_set_id"], UUID(_MODEL_ID)
@@ -163,13 +165,14 @@ class TestSaveLoadModel(unittest.TestCase):
 class TestRefitGuard(unittest.TestCase):
     def test_load_by_id_cannot_auto_refit(self):
         reg = TabPFNRegressor(model_id=_MODEL_ID)  # no in-memory train data
-        with patch.object(ServiceClient, "get_model_limits", return_value=None):
-            with patch.object(InferenceClient, "fit") as mock_fit:
-                with patch.object(
-                    InferenceClient, "predict", side_effect=NeedsRefittingError()
-                ):
-                    with self.assertRaises(RuntimeError) as ctx:
-                        reg.predict(np.random.randn(4, 3))
+        with patch("tabpfn_client.estimator.init"):
+            with patch.object(ServiceClient, "get_model_limits", return_value=None):
+                with patch.object(InferenceClient, "fit") as mock_fit:
+                    with patch.object(
+                        InferenceClient, "predict", side_effect=NeedsRefittingError()
+                    ):
+                        with self.assertRaises(RuntimeError) as ctx:
+                            reg.predict(np.random.randn(4, 3))
         self.assertIn("no in-memory", str(ctx.exception).lower())
         mock_fit.assert_not_called()
 
@@ -195,6 +198,19 @@ class TestSklearnCompatibility(unittest.TestCase):
                 _resolve_train_set_id(cloned), UUID(_MODEL_ID), Est.__name__
             )
             self.assertTrue(cloned.__sklearn_is_fitted__(), Est.__name__)
+
+    def test_invalid_model_id_reports_unfitted_not_crash(self):
+        # Constructor stores `model_id` verbatim (sklearn convention: no
+        # validation in __init__). A bad id must not crash sklearn's
+        # fittedness check — it should degrade to "not fitted".
+        from sklearn.exceptions import NotFittedError
+        from sklearn.utils.validation import check_is_fitted
+
+        for Est in (TabPFNClassifier, TabPFNRegressor):
+            est = Est(model_id="not-a-uuid")
+            self.assertFalse(est.__sklearn_is_fitted__(), Est.__name__)
+            with self.assertRaises(NotFittedError):
+                check_is_fitted(est)
 
     def test_predict_triggers_init_from_cold_state(self):
         # A fresh process that only calls `load_model(...).predict(...)` never

--- a/tests/unit/test_fit_mode_and_model_id.py
+++ b/tests/unit/test_fit_mode_and_model_id.py
@@ -1,9 +1,9 @@
 """Unit tests for the KV-cache client surface:
 
 - `fit_mode` reaching the server-side `tabpfn_config` on the wire,
-- the `model_id` constructor param (Option 1) making an estimator "fitted"
-  and predictable without a local `fit()`,
-- `save_model()` / `load_model()` round-trips (Option 3),
+- `model_id_` (the fitted-train-set id, written by `fit()`/`load_model()`)
+  as the single fitted-state slot that makes an estimator predictable,
+- `save_model()` / `load_model()` round-trips,
 - the refit-fallback guard for load-by-id estimators.
 
 These stay hermetic by patching `InferenceClient` / `ServiceClient` rather
@@ -19,11 +19,7 @@ import numpy as np
 
 from tabpfn_client.api_models import FitMode
 from tabpfn_client.client import NeedsRefittingError, PredictionResult, ServiceClient
-from tabpfn_client.estimator import (
-    TabPFNClassifier,
-    TabPFNRegressor,
-    _resolve_train_set_id,
-)
+from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
 from tabpfn_client.service_wrapper import InferenceClient
 
 _MODEL_ID = "00000000-0000-0000-0000-000000000abc"
@@ -50,7 +46,8 @@ class TestFitMode(unittest.TestCase):
             self.assertEqual(dumped.get("fit_mode"), "fit_with_cache", Est.__name__)
 
     def test_fit_mode_forwarded_on_predict_task_config(self):
-        reg = TabPFNRegressor(fit_mode=FitMode.FIT_WITH_CACHE, model_id=_MODEL_ID)
+        reg = TabPFNRegressor(fit_mode=FitMode.FIT_WITH_CACHE)
+        reg.model_id_ = UUID(_MODEL_ID)
         with patch("tabpfn_client.estimator.init"):
             with patch.object(ServiceClient, "get_model_limits", return_value=None):
                 with patch.object(
@@ -62,16 +59,17 @@ class TestFitMode(unittest.TestCase):
         self.assertEqual(dumped.get("fit_mode"), "fit_with_cache")
 
 
-class TestModelIdConstructor(unittest.TestCase):
+class TestModelIdFittedState(unittest.TestCase):
     def test_model_id_marks_estimator_fitted(self):
         for Est in (TabPFNClassifier, TabPFNRegressor):
-            est = Est(model_id=_MODEL_ID)
+            est = Est()
+            self.assertFalse(est.__sklearn_is_fitted__(), Est.__name__)
+            est.model_id_ = UUID(_MODEL_ID)
             self.assertTrue(est.__sklearn_is_fitted__(), Est.__name__)
-            self.assertEqual(_resolve_train_set_id(est), UUID(_MODEL_ID))
-            self.assertFalse(Est().__sklearn_is_fitted__(), Est.__name__)
 
     def test_predict_uses_model_id_without_fitting(self):
-        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        reg = TabPFNRegressor()
+        reg.model_id_ = UUID(_MODEL_ID)
         with patch("tabpfn_client.estimator.init"):
             with patch.object(ServiceClient, "get_model_limits", return_value=None):
                 with patch.object(InferenceClient, "fit") as mock_fit:
@@ -84,56 +82,50 @@ class TestModelIdConstructor(unittest.TestCase):
             mock_predict.call_args[1]["fitted_train_set_id"], UUID(_MODEL_ID)
         )
 
-    def test_model_id_accepts_uuid_and_str(self):
-        self.assertEqual(
-            _resolve_train_set_id(TabPFNRegressor(model_id=UUID(_MODEL_ID))),
-            UUID(_MODEL_ID),
-        )
-
 
 class TestSaveLoadModel(unittest.TestCase):
     def test_regressor_round_trip_dict(self):
-        reg = TabPFNRegressor(model_id=_MODEL_ID, n_estimators=4)
+        reg = TabPFNRegressor(n_estimators=4)
+        reg.model_id_ = UUID(_MODEL_ID)
         handle = reg.save_model()
         self.assertEqual(handle["task"], "regression")
+        self.assertEqual(handle["model_id"], _MODEL_ID)
+        # `model_id_` is fitted state, not a constructor param, so it must not
+        # leak into the params blob.
+        self.assertNotIn("model_id", handle["params"])
         self.assertNotIn("client_options", handle["params"])
-        self.assertEqual(handle["params"]["model_id"], _MODEL_ID)
 
         loaded = TabPFNRegressor.load_model(handle)
         self.assertTrue(loaded.__sklearn_is_fitted__())
-        self.assertEqual(_resolve_train_set_id(loaded), UUID(_MODEL_ID))
+        self.assertEqual(loaded.model_id_, UUID(_MODEL_ID))
         self.assertEqual(loaded.get_params()["n_estimators"], 4)
 
     def test_classifier_round_trip_restores_classes(self):
-        clf = TabPFNClassifier(model_id=_MODEL_ID)
+        clf = TabPFNClassifier()
+        clf.model_id_ = UUID(_MODEL_ID)
         clf.classes_ = np.array([0, 1, 2])
         loaded = TabPFNClassifier.load_model(clf.save_model())
         self.assertTrue(loaded.__sklearn_is_fitted__())
+        self.assertEqual(loaded.model_id_, UUID(_MODEL_ID))
         np.testing.assert_array_equal(loaded.classes_, np.array([0, 1, 2]))
 
     def test_round_trip_via_file(self):
         import tempfile
         from pathlib import Path
 
-        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        reg = TabPFNRegressor()
+        reg.model_id_ = UUID(_MODEL_ID)
         with tempfile.TemporaryDirectory() as d:
             path = Path(d) / "model.json"
             returned = reg.save_model(path)
             self.assertEqual(Path(returned), path)
             self.assertTrue(path.exists())
             loaded = TabPFNRegressor.load_model(path)
-        self.assertEqual(_resolve_train_set_id(loaded), UUID(_MODEL_ID))
-
-    def test_effective_id_beats_constructor_model_id(self):
-        # A real fit supersedes the constructor's model_id; save_model must
-        # persist the effective (post-fit) id, not the original.
-        reg = TabPFNRegressor(model_id=_MODEL_ID)
-        new_id = "00000000-0000-0000-0000-000000000fff"
-        reg.fitted_train_set_id_ = UUID(new_id)
-        self.assertEqual(reg.save_model()["params"]["model_id"], new_id)
+        self.assertEqual(loaded.model_id_, UUID(_MODEL_ID))
 
     def test_load_model_task_mismatch_raises(self):
-        clf = TabPFNClassifier(model_id=_MODEL_ID)
+        clf = TabPFNClassifier()
+        clf.model_id_ = UUID(_MODEL_ID)
         clf.classes_ = np.array([0, 1])
         with self.assertRaises(ValueError):
             TabPFNRegressor.load_model(clf.save_model())
@@ -144,16 +136,10 @@ class TestSaveLoadModel(unittest.TestCase):
         with self.assertRaises(NotFittedError):
             TabPFNRegressor().save_model()
 
-    def test_save_classifier_without_classes_raises(self):
-        # A bare model_id classifier is "fitted" (has an id) but has no
-        # classes_ to persist; save_model must fail clearly, not AttributeError.
-        clf = TabPFNClassifier(model_id=_MODEL_ID)
-        with self.assertRaises(ValueError) as ctx:
-            clf.save_model()
-        self.assertIn("classes_", str(ctx.exception))
-
     def test_unsupported_handle_version_raises(self):
-        handle = TabPFNRegressor(model_id=_MODEL_ID).save_model()
+        reg = TabPFNRegressor()
+        reg.model_id_ = UUID(_MODEL_ID)
+        handle = reg.save_model()
         handle["format_version"] = 999
         with self.assertRaises(ValueError):
             TabPFNRegressor.load_model(handle)
@@ -161,7 +147,8 @@ class TestSaveLoadModel(unittest.TestCase):
 
 class TestRefitGuard(unittest.TestCase):
     def test_load_by_id_cannot_auto_refit(self):
-        reg = TabPFNRegressor(model_id=_MODEL_ID)  # no in-memory train data
+        reg = TabPFNRegressor()
+        reg.model_id_ = UUID(_MODEL_ID)  # no in-memory train data
         with patch("tabpfn_client.estimator.init"):
             with patch.object(ServiceClient, "get_model_limits", return_value=None):
                 with patch.object(InferenceClient, "fit") as mock_fit:
@@ -175,36 +162,31 @@ class TestRefitGuard(unittest.TestCase):
 
 
 class TestSklearnCompatibility(unittest.TestCase):
-    def test_clone_preserves_model_id_and_stays_fitted(self):
-        # `clone` calls `get_params()` and re-instantiates. `model_id` is a
-        # constructor param, so the clone must keep it (and thus still be
-        # considered fitted for the load-by-id path) — this covers the
-        # get_params/clone desync surfaced by cursor.
+    def test_clone_drops_fitted_state(self):
+        # `model_id_` is fitted state, not a constructor param, so `clone`
+        # must NOT carry it over: clones start unfitted and CV folds refit
+        # cleanly instead of inheriting a pointer to remote fitted state.
         from sklearn.base import clone
 
         from typing import Any, cast as _cast
 
         for Est in (TabPFNClassifier, TabPFNRegressor):
-            original = Est(model_id=_MODEL_ID)
+            original = Est(n_estimators=4)
+            original.model_id_ = UUID(_MODEL_ID)
             # `clone`'s overloaded return over a `type[C] | type[R]` union
             # confuses pyright; runtime type is Est, but we cast to Any to
             # avoid re-typing at every call site below.
             cloned = _cast(Any, clone(original))
-            self.assertEqual(cloned.get_params()["model_id"], _MODEL_ID, Est.__name__)
-            self.assertEqual(
-                _resolve_train_set_id(cloned), UUID(_MODEL_ID), Est.__name__
-            )
-            self.assertTrue(cloned.__sklearn_is_fitted__(), Est.__name__)
+            self.assertFalse(cloned.__sklearn_is_fitted__(), Est.__name__)
+            self.assertNotIn("model_id", cloned.get_params(), Est.__name__)
+            self.assertEqual(cloned.get_params()["n_estimators"], 4, Est.__name__)
 
-    def test_invalid_model_id_reports_unfitted_not_crash(self):
-        # Constructor stores `model_id` verbatim (sklearn convention: no
-        # validation in __init__). A bad id must not crash sklearn's
-        # fittedness check — it should degrade to "not fitted".
+    def test_unfitted_estimator_raises_not_fitted(self):
         from sklearn.exceptions import NotFittedError
         from sklearn.utils.validation import check_is_fitted
 
         for Est in (TabPFNClassifier, TabPFNRegressor):
-            est = Est(model_id="not-a-uuid")
+            est = Est()
             self.assertFalse(est.__sklearn_is_fitted__(), Est.__name__)
             with self.assertRaises(NotFittedError):
                 check_is_fitted(est)
@@ -213,7 +195,8 @@ class TestSklearnCompatibility(unittest.TestCase):
         # A fresh process that only calls `load_model(...).predict(...)` never
         # touches `fit()`, so `_predict` itself must call `init()` to authorize
         # the HTTP client — otherwise the main cross-process reuse path 401s.
-        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        reg = TabPFNRegressor()
+        reg.model_id_ = UUID(_MODEL_ID)
         with patch("tabpfn_client.estimator.init") as mock_init:
             with patch.object(ServiceClient, "get_model_limits", return_value=None):
                 with patch.object(

--- a/tests/unit/test_fit_mode_and_model_id.py
+++ b/tests/unit/test_fit_mode_and_model_id.py
@@ -1,0 +1,174 @@
+"""Unit tests for the KV-cache client surface:
+
+- `fit_mode` reaching the server-side `tabpfn_config` on the wire,
+- the `model_id` constructor param (Option 1) making an estimator "fitted"
+  and predictable without a local `fit()`,
+- `save_model()` / `load_model()` round-trips (Option 3),
+- the refit-fallback guard for load-by-id estimators.
+
+These stay hermetic by patching `InferenceClient` / `ServiceClient` rather
+than talking to a mock server — the concern here is client-side wiring, not
+the HTTP layer.
+"""
+
+import unittest
+from unittest.mock import patch
+from uuid import UUID
+
+import numpy as np
+
+from tabpfn_client.client import NeedsRefittingError, PredictionResult, ServiceClient
+from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
+from tabpfn_client.service_wrapper import InferenceClient
+
+_MODEL_ID = "00000000-0000-0000-0000-000000000abc"
+
+
+def _regressor_prediction() -> PredictionResult:
+    return PredictionResult(y_pred={"mean": np.zeros(4)}, metadata={})
+
+
+def _classifier_prediction() -> PredictionResult:
+    return PredictionResult(y_pred=np.zeros(4), metadata={})
+
+
+class TestFitMode(unittest.TestCase):
+    def test_default_omits_fit_mode_on_wire(self):
+        # Default is None, so nothing is sent and the server applies its own
+        # default (fit_preprocessors) — matching the SDK's "None means unset"
+        # convention for server-backed config fields.
+        for Est in (TabPFNClassifier, TabPFNRegressor):
+            cfg = Est()._get_tabpfn_config()
+            dumped = cfg.model_dump(mode="json", exclude_none=True)
+            self.assertNotIn("fit_mode", dumped, Est.__name__)
+
+    def test_fit_with_cache_reaches_wire_config(self):
+        for Est in (TabPFNClassifier, TabPFNRegressor):
+            cfg = Est(fit_mode="fit_with_cache")._get_tabpfn_config()
+            dumped = cfg.model_dump(mode="json", exclude_none=True)
+            self.assertEqual(dumped.get("fit_mode"), "fit_with_cache", Est.__name__)
+
+    def test_fit_mode_forwarded_on_predict_task_config(self):
+        reg = TabPFNRegressor(fit_mode="fit_with_cache", model_id=_MODEL_ID)
+        with patch.object(ServiceClient, "get_model_limits", return_value=None):
+            with patch.object(
+                InferenceClient, "predict", return_value=_regressor_prediction()
+            ) as mock_predict:
+                reg.predict(np.random.randn(4, 3))
+        task_config = mock_predict.call_args[1]["task_config"]
+        dumped = task_config.tabpfn_config.model_dump(mode="json", exclude_none=True)
+        self.assertEqual(dumped.get("fit_mode"), "fit_with_cache")
+
+
+class TestModelIdConstructor(unittest.TestCase):
+    def test_model_id_marks_estimator_fitted(self):
+        for Est in (TabPFNClassifier, TabPFNRegressor):
+            est = Est(model_id=_MODEL_ID)
+            self.assertTrue(est.__sklearn_is_fitted__(), Est.__name__)
+            self.assertEqual(est._last_fitted_train_set_id, UUID(_MODEL_ID))
+            self.assertFalse(Est().__sklearn_is_fitted__(), Est.__name__)
+
+    def test_predict_uses_model_id_without_fitting(self):
+        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        with patch.object(ServiceClient, "get_model_limits", return_value=None):
+            with patch.object(InferenceClient, "fit") as mock_fit:
+                with patch.object(
+                    InferenceClient, "predict", return_value=_regressor_prediction()
+                ) as mock_predict:
+                    reg.predict(np.random.randn(4, 3))
+        mock_fit.assert_not_called()
+        self.assertEqual(
+            mock_predict.call_args[1]["fitted_train_set_id"], UUID(_MODEL_ID)
+        )
+
+    def test_model_id_accepts_uuid_and_str(self):
+        self.assertEqual(
+            TabPFNRegressor(model_id=UUID(_MODEL_ID))._last_fitted_train_set_id,
+            UUID(_MODEL_ID),
+        )
+
+
+class TestSaveLoadModel(unittest.TestCase):
+    def test_regressor_round_trip_dict(self):
+        reg = TabPFNRegressor(model_id=_MODEL_ID, n_estimators=4)
+        handle = reg.save_model()
+        self.assertEqual(handle["task"], "regression")
+        self.assertNotIn("client_options", handle["params"])
+        self.assertEqual(handle["params"]["model_id"], _MODEL_ID)
+
+        loaded = TabPFNRegressor.load_model(handle)
+        self.assertTrue(loaded.__sklearn_is_fitted__())
+        self.assertEqual(loaded._last_fitted_train_set_id, UUID(_MODEL_ID))
+        self.assertEqual(loaded.get_params()["n_estimators"], 4)
+
+    def test_classifier_round_trip_restores_classes(self):
+        clf = TabPFNClassifier(model_id=_MODEL_ID)
+        clf.classes_ = np.array([0, 1, 2])
+        loaded = TabPFNClassifier.load_model(clf.save_model())
+        self.assertTrue(loaded.__sklearn_is_fitted__())
+        np.testing.assert_array_equal(loaded.classes_, np.array([0, 1, 2]))
+
+    def test_round_trip_via_file(self):
+        import tempfile
+        from pathlib import Path
+
+        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "model.json"
+            returned = reg.save_model(path)
+            self.assertEqual(Path(returned), path)
+            self.assertTrue(path.exists())
+            loaded = TabPFNRegressor.load_model(path)
+        self.assertEqual(loaded._last_fitted_train_set_id, UUID(_MODEL_ID))
+
+    def test_effective_id_beats_constructor_model_id(self):
+        # A real fit supersedes the constructor's model_id; save_model must
+        # persist the effective (post-fit) id, not the original.
+        reg = TabPFNRegressor(model_id=_MODEL_ID)
+        new_id = "00000000-0000-0000-0000-000000000fff"
+        reg._last_fitted_train_set_id = UUID(new_id)
+        self.assertEqual(reg.save_model()["params"]["model_id"], new_id)
+
+    def test_load_model_task_mismatch_raises(self):
+        clf = TabPFNClassifier(model_id=_MODEL_ID)
+        clf.classes_ = np.array([0, 1])
+        with self.assertRaises(ValueError):
+            TabPFNRegressor.load_model(clf.save_model())
+
+    def test_save_model_unfitted_raises(self):
+        from sklearn.exceptions import NotFittedError
+
+        with self.assertRaises(NotFittedError):
+            TabPFNRegressor().save_model()
+
+    def test_save_classifier_without_classes_raises(self):
+        # A bare model_id classifier is "fitted" (has an id) but has no
+        # classes_ to persist; save_model must fail clearly, not AttributeError.
+        clf = TabPFNClassifier(model_id=_MODEL_ID)
+        with self.assertRaises(ValueError) as ctx:
+            clf.save_model()
+        self.assertIn("classes_", str(ctx.exception))
+
+    def test_unsupported_handle_version_raises(self):
+        handle = TabPFNRegressor(model_id=_MODEL_ID).save_model()
+        handle["format_version"] = 999
+        with self.assertRaises(ValueError):
+            TabPFNRegressor.load_model(handle)
+
+
+class TestRefitGuard(unittest.TestCase):
+    def test_load_by_id_cannot_auto_refit(self):
+        reg = TabPFNRegressor(model_id=_MODEL_ID)  # no in-memory train data
+        with patch.object(ServiceClient, "get_model_limits", return_value=None):
+            with patch.object(InferenceClient, "fit") as mock_fit:
+                with patch.object(
+                    InferenceClient, "predict", side_effect=NeedsRefittingError()
+                ):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        reg.predict(np.random.randn(4, 3))
+        self.assertIn("no in-memory", str(ctx.exception).lower())
+        mock_fit.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -536,7 +536,9 @@ class TestTabPFNClassifierInference(unittest.TestCase):
     def test_predict_params_output_type(self):
         """Test that predict_params contains correct output_type."""
         classifier = TabPFNClassifier()
-        classifier.model_id_ = UUID("00000000-0000-0000-0000-000000000000")  # Skip fitting
+        classifier.model_id_ = UUID(
+            "00000000-0000-0000-0000-000000000000"
+        )  # Skip fitting
         test_X = np.random.randn(10, 5)
 
         # Test predict() sets output_type to "preds"

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -498,9 +498,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
 
         # Skip fitting
         classifier.fitted_ = True
-        classifier.fitted_train_set_id_ = UUID(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        classifier.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         test_X = np.random.randn(10, 5)
 

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -451,7 +451,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         tabpfn = TabPFNClassifier()
 
         # skip fitting
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         # test oversized cells
         with self.assertRaises(ValueError):
@@ -462,7 +462,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         tabpfn = TabPFNClassifier()
 
         # skip fitting
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         tabpfn.classes_ = np.array([0, 1])
 
         # mock prediction
@@ -497,8 +497,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         )
 
         # Skip fitting
-        classifier.fitted_ = True
-        classifier.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
+        classifier.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         test_X = np.random.randn(10, 5)
 
@@ -537,7 +536,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
     def test_predict_params_output_type(self):
         """Test that predict_params contains correct output_type."""
         classifier = TabPFNClassifier()
-        classifier.fitted_ = True  # Skip fitting
+        classifier.model_id_ = UUID("00000000-0000-0000-0000-000000000000")  # Skip fitting
         test_X = np.random.randn(10, 5)
 
         # Test predict() sets output_type to "preds"
@@ -608,7 +607,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         """Test predictions with long text (>2500 chars) and text containing commas."""
         # Skip initialization
         tabpfn = TabPFNClassifier()
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         tabpfn.classes_ = np.array([0, 1])  # Binary classification
 
         # Create test data with a mix of numeric and text features
@@ -747,7 +746,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
 
         # Skip initialization
         tabpfn = TabPFNClassifier()
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         tabpfn.classes_ = np.array([0, 1])
 
         # Create test data

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -498,7 +498,7 @@ class TestTabPFNClassifierInference(unittest.TestCase):
 
         # Skip fitting
         classifier.fitted_ = True
-        classifier._last_fitted_train_set_id = UUID(
+        classifier.fitted_train_set_id_ = UUID(
             "00000000-0000-0000-0000-000000000000"
         )
 

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -492,9 +492,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
 
         # Skip fitting
         regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         test_X = np.random.randn(10, 5)
 
@@ -602,9 +600,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_full_adds_criterion_with_optional_dependencies(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
         regressor._last_train_X = np.random.randn(5, 2)
         regressor._last_train_y = np.random.randn(5)
 
@@ -651,9 +647,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_full_missing_optional_dependencies_logs_warning(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
         regressor._last_train_X = np.random.randn(5, 2)
         regressor._last_train_y = np.random.randn(5)
 

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -447,7 +447,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         tabpfn = TabPFNRegressor()
 
         # skip fitting
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         # test oversized cells
         with self.assertRaises(ValueError):
@@ -458,7 +458,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         tabpfn = TabPFNRegressor()
 
         # skip fitting
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         # mock prediction
         with patch.object(InferenceClient, "predict") as mock_predict:
@@ -491,8 +491,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         )
 
         # Skip fitting
-        regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         test_X = np.random.randn(10, 5)
 
@@ -531,7 +530,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_params_output_type(self):
         """Test that predict_params contains correct output_type and quantiles."""
         regressor = TabPFNRegressor()
-        regressor.fitted_ = True  # Skip fitting
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")  # Skip fitting
         test_X = np.random.randn(10, 5)
 
         # Test default predict() sets output_type to "mean"
@@ -561,7 +560,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         """Server returns a stacked (n_quantiles, n_samples) array; predict()
         normalizes it to a list of per-quantile arrays, matching local tabpfn."""
         regressor = TabPFNRegressor()
-        regressor.fitted_ = True
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         test_X = np.random.randn(20, 5)
         quantiles = [0.1, 0.5, 0.9]
 
@@ -583,7 +582,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         """A single quantile may arrive squeezed to 1D; it must still become a
         list of one (n_samples,) array, matching local tabpfn."""
         regressor = TabPFNRegressor()
-        regressor.fitted_ = True
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         test_X = np.random.randn(20, 5)
 
         with patch.object(InferenceClient, "predict") as mock_predict:
@@ -599,8 +598,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
 
     def test_predict_full_adds_criterion_with_optional_dependencies(self):
         regressor = TabPFNRegressor()
-        regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         regressor._last_train_X = np.random.randn(5, 2)
         regressor._last_train_y = np.random.randn(5)
 
@@ -646,8 +644,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
 
     def test_predict_full_missing_optional_dependencies_logs_warning(self):
         regressor = TabPFNRegressor()
-        regressor.fitted_ = True
-        regressor.fitted_train_set_id_ = UUID("00000000-0000-0000-0000-000000000000")
+        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         regressor._last_train_X = np.random.randn(5, 2)
         regressor._last_train_y = np.random.randn(5)
 
@@ -681,7 +678,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         """Test predictions with long text (>2500 chars) and text containing commas."""
         # Skip initialization
         tabpfn = TabPFNRegressor()
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         # Create test data with a mix of numeric and text features
         n_samples = 5
@@ -768,7 +765,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
 
         # Skip initialization
         tabpfn = TabPFNRegressor()
-        tabpfn.fitted_ = True
+        tabpfn.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
 
         # Create test data
         n_samples = 5

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -492,7 +492,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
 
         # Skip fitting
         regressor.fitted_ = True
-        regressor._last_fitted_train_set_id = UUID(
+        regressor.fitted_train_set_id_ = UUID(
             "00000000-0000-0000-0000-000000000000"
         )
 
@@ -602,7 +602,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_full_adds_criterion_with_optional_dependencies(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True
-        regressor._last_fitted_train_set_id = UUID(
+        regressor.fitted_train_set_id_ = UUID(
             "00000000-0000-0000-0000-000000000000"
         )
         regressor._last_train_X = np.random.randn(5, 2)
@@ -651,7 +651,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_full_missing_optional_dependencies_logs_warning(self):
         regressor = TabPFNRegressor()
         regressor.fitted_ = True
-        regressor._last_fitted_train_set_id = UUID(
+        regressor.fitted_train_set_id_ = UUID(
             "00000000-0000-0000-0000-000000000000"
         )
         regressor._last_train_X = np.random.randn(5, 2)

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -530,7 +530,9 @@ class TestTabPFNRegressorInference(unittest.TestCase):
     def test_predict_params_output_type(self):
         """Test that predict_params contains correct output_type and quantiles."""
         regressor = TabPFNRegressor()
-        regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")  # Skip fitting
+        regressor.model_id_ = UUID(
+            "00000000-0000-0000-0000-000000000000"
+        )  # Skip fitting
         test_X = np.random.randn(10, 5)
 
         # Test default predict() sets output_type to "mean"


### PR DESCRIPTION
### Change Description

- Enable `fit_with_cache` predictions - previously setting the `fit_mode` was blocked by the API.
- Naming conventions - refactor to be closer with `scikit-learn` standards.