### PR TITLE
Add Azure AI Foundry TabPFN client with thinking-mode support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"

--- a/src/tabpfn_client/foundry/__init__.py
+++ b/src/tabpfn_client/foundry/__init__.py
@@ -5,7 +5,11 @@
 from tabpfn_client.foundry import TabPFNClassifier, TabPFNRegressor
 """
 
-from tabpfn_client.foundry.estimator import TabPFNClassifier, TabPFNRegressor
+from tabpfn_client.foundry.estimator import (
+    FoundryEndpointError,
+    TabPFNClassifier,
+    TabPFNRegressor,
+)
 
 
-__all__ = ["TabPFNClassifier", "TabPFNRegressor"]
+__all__ = ["FoundryEndpointError", "TabPFNClassifier", "TabPFNRegressor"]

--- a/src/tabpfn_client/foundry/estimator.py
+++ b/src/tabpfn_client/foundry/estimator.py
@@ -10,19 +10,23 @@ The training data is shipped to the endpoint on the next `predict*`
 call, where the actual fit runs.
 
 This client sends requests as `application/json` only (Foundry also
-accepts `multipart/form-data`, but we don't use it here) and does not
-currently support thinking mode.
+accepts `multipart/form-data`, but we don't use it here).
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, cast
 
 import httpx
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
+
+from tabpfn_client.models import FitModeLiteral
+
+
+ThinkingEffort = Literal["medium", "high"]
 
 
 def _to_jsonable(X: Any) -> list:
@@ -42,12 +46,17 @@ def _build_request_body(
     X_train: Optional[Any] = None,
     y_train: Optional[Any] = None,
     cached_model_id: Optional[str] = None,
+    thinking_block: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Assemble a Foundry `/predict` JSON body.
 
     When `cached_model_id` is provided, the body targets the V3 cache-hit
     path: `X_train` / `y_train` are omitted and a `context.model_id` is
     sent instead. Otherwise training data is shipped inline.
+
+    When `thinking_block` is provided (non-empty), its fields are merged
+    at the top level of the request body (e.g. `thinking_effort`,
+    `thinking_timeout_s`, `thinking_metric`).
     """
     body: Dict[str, Any] = {
         "task_config": {
@@ -57,6 +66,8 @@ def _build_request_body(
         },
         "x_test": _to_jsonable(X_test),
     }
+    if thinking_block:
+        body.update(thinking_block)
 
     # Build up the KV-cache context if we have a model_id,
     # otherwise ship the training data
@@ -91,7 +102,12 @@ class _FoundryBase(BaseEstimator):
         random_state: Optional[int] = 0,
         inference_config: Optional[Dict[str, Any]] = None,
         paper_version: bool = False,
+        thinking_mode: bool = False,
+        thinking_effort: Optional[ThinkingEffort] = None,
+        thinking_timeout_s: Optional[float] = None,
+        thinking_metric: Optional[str] = None,
         use_kv_cache: bool = False,
+        fit_mode: Optional[FitModeLiteral] = None,
         timeout_s: float = 300.0,
     ):
         self.endpoint_url = endpoint_url
@@ -106,8 +122,51 @@ class _FoundryBase(BaseEstimator):
         self.random_state = random_state
         self.inference_config = inference_config
         self.paper_version = paper_version
+        self.thinking_mode = thinking_mode
+        self.thinking_effort = thinking_effort
+        self.thinking_timeout_s = thinking_timeout_s
+        self.thinking_metric = thinking_metric
         self.use_kv_cache = use_kv_cache
+        self.fit_mode = fit_mode
         self.timeout_s = timeout_s
+        self._validate_args()
+
+    def _validate_args(self) -> None:
+        """Reject settings that would silently disable caching for a
+        configuration that plainly asked for it."""
+        if self.fit_mode == "fit_preprocessors":
+            if self.use_kv_cache:
+                raise ValueError(
+                    "Conflicting settings: fit_mode='fit_preprocessors' "
+                    "cannot be combined with use_kv_cache=True. Either drop "
+                    "use_kv_cache or set fit_mode='fit_with_cache'."
+                )
+            if self.thinking_mode or self.thinking_effort is not None:
+                raise ValueError(
+                    "Conflicting settings: fit_mode='fit_preprocessors' "
+                    "cannot be combined with thinking mode (thinking_mode=True "
+                    "or thinking_effort set). Thinking mode requires caching; "
+                    "either drop the thinking-mode params or set "
+                    "fit_mode='fit_with_cache' (or leave fit_mode unset)."
+                )
+
+    @property
+    def _thinking_active(self) -> bool:
+        return self.thinking_mode or self.thinking_effort is not None
+
+    @property
+    def _effective_fit_mode(self) -> FitModeLiteral:
+        # Explicit `fit_mode` wins; `_validate_args` guarantees it doesn't
+        # conflict with `use_kv_cache` / thinking mode.
+        if self.fit_mode is not None:
+            return cast(FitModeLiteral, self.fit_mode)
+        if self.use_kv_cache or self._thinking_active:
+            return "fit_with_cache"
+        return "fit_preprocessors"
+
+    @property
+    def _cache_active(self) -> bool:
+        return self._effective_fit_mode == "fit_with_cache"
 
     def _build_tabpfn_config(self) -> Dict[str, Any]:
         cfg: Dict[str, Any] = {
@@ -118,13 +177,28 @@ class _FoundryBase(BaseEstimator):
             "inference_precision": self.inference_precision,
             "random_state": self.random_state,
             "inference_config": self.inference_config,
-            "fit_mode": "fit_with_cache" if self.use_kv_cache else "fit_preprocessors",
+            "fit_mode": self._effective_fit_mode,
         }
 
         if self._task == "classification":
             cfg["balance_probabilities"] = self.balance_probabilities
 
         return cfg
+
+    def _build_thinking_block(self) -> Dict[str, Any]:
+        """Top-level wire fields for thinking-mode. Empty when inactive."""
+        if not self._thinking_active:
+            return {}
+        block: Dict[str, Any] = {
+            "thinking_effort": self.thinking_effort
+            if self.thinking_effort is not None
+            else "medium",
+        }
+        if self.thinking_timeout_s is not None:
+            block["thinking_timeout_s"] = self.thinking_timeout_s
+        if self.thinking_metric is not None:
+            block["thinking_metric"] = self.thinking_metric
+        return block
 
     def _headers(self) -> Dict[str, str]:
         return {
@@ -183,7 +257,8 @@ class _FoundryBase(BaseEstimator):
             X_test=X_test,
             X_train=self.X_train_,
             y_train=self.y_train_,
-            cached_model_id=self._cached_model_id if self.use_kv_cache else None,
+            cached_model_id=self._cached_model_id if self._cache_active else None,
+            thinking_block=self._build_thinking_block(),
         )
         resp = self._http_client().post(
             self.endpoint_url,
@@ -192,7 +267,7 @@ class _FoundryBase(BaseEstimator):
         )
         resp.raise_for_status()
         payload = resp.json()
-        if self.use_kv_cache:
+        if self._cache_active:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id
         return payload
 

--- a/src/tabpfn_client/foundry/estimator.py
+++ b/src/tabpfn_client/foundry/estimator.py
@@ -15,7 +15,7 @@ accepts `multipart/form-data`, but we don't use it here).
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, cast
+from typing import Any, Dict, Literal, Optional, Union, cast
 
 import httpx
 import numpy as np
@@ -104,6 +104,30 @@ def _to_jsonable(X: Any) -> list:
     if isinstance(X, pd.Series):
         return X.tolist()
     return np.asarray(X).tolist()
+
+
+def _contains_none(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, list):
+        return any(_contains_none(item) for item in value)
+    return False
+
+
+def _normalize_prediction_dict(prediction: Dict[str, Any]) -> Dict[str, np.ndarray]:
+    """Coerce a wire-format prediction dict (JSON lists) to `{str: ndarray}`.
+
+    Mirrors `tabpfn_client.client.InferenceClient.predict` so callers get the
+    same `dict[str, np.ndarray]` shape on Foundry as on the hosted client.
+    """
+    result: Dict[str, np.ndarray] = {}
+    for k, v in prediction.items():
+        if isinstance(v, list):
+            dtype = float if _contains_none(v) else None
+            result[k] = np.array(v, dtype=dtype)
+        else:
+            result[k] = v
+    return result
 
 
 def _build_request_body(
@@ -419,11 +443,24 @@ class TabPFNRegressor(_FoundryBase, RegressorMixin):
     def predict(
         self,
         X: Any,
-        output_type: str = "mean",
+        output_type: Literal[
+            "mean", "median", "mode", "quantiles", "full", "main"
+        ] = "mean",
         quantiles: Optional[list] = None,
-    ) -> np.ndarray:
+    ) -> Union[np.ndarray, list, Dict[str, np.ndarray]]:
         predict_params: Dict[str, Any] = {}
         if quantiles is not None:
             predict_params["quantiles"] = quantiles
         result = self._invoke(X, output_type=output_type, predict_params=predict_params)
-        return np.asarray(result["prediction"])
+        output = result["prediction"]
+
+        # Dispatch on wire shape rather than `output_type` so any dict-shaped
+        # response (`"full"`, `"main"`, or future ones) gets the same treatment.
+        if isinstance(output, dict):
+            return _normalize_prediction_dict(output)
+
+        if output_type == "quantiles":
+            arr = np.asarray(output)
+            return list(arr) if arr.ndim == 2 else [arr]
+
+        return np.asarray(output)

--- a/src/tabpfn_client/foundry/estimator.py
+++ b/src/tabpfn_client/foundry/estimator.py
@@ -28,6 +28,74 @@ from tabpfn_client.models import FitModeLiteral
 
 ThinkingEffort = Literal["medium", "high"]
 
+# The endpoint validates these server-side and answers an out-of-range value
+# with an opaque HTTP 424, so we mirror the accepted sets here to fail fast
+# with an actionable message instead.
+_VALID_THINKING_EFFORTS: tuple = ("medium", "high")
+_VALID_THINKING_METRICS: Dict[str, tuple] = {
+    "classification": ("accuracy", "log_loss", "balanced_accuracy"),
+    "regression": ("rmse", "mse", "mae", "r2"),
+}
+
+
+class FoundryEndpointError(httpx.HTTPStatusError):
+    """A non-2xx answer from the Foundry endpoint, with its error payload.
+
+    Subclasses `httpx.HTTPStatusError`, so callers that already catch that
+    keep working. The endpoint reports failures as a JSON body carrying
+    `error_code` and `trace_id`; both are surfaced on the exception (and in
+    its message) because the `trace_id` is what the endpoint provider needs
+    in order to look the failure up server-side.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request: Any,
+        response: Any,
+        error_code: Optional[str] = None,
+        trace_id: Optional[str] = None,
+    ):
+        super().__init__(message, request=request, response=response)
+        self.error_code = error_code
+        self.trace_id = trace_id
+
+
+def _raise_for_status(resp: httpx.Response) -> None:
+    """Raise `FoundryEndpointError` carrying the endpoint's error payload."""
+    if not resp.is_error:
+        return
+
+    detail, error_code, trace_id = "", None, None
+    try:
+        payload = resp.json()
+    except Exception:
+        detail = resp.text[:500]
+    else:
+        if isinstance(payload, dict):
+            error_code = payload.get("error_code")
+            trace_id = payload.get("trace_id")
+            detail = payload.get("message") or ""
+        else:
+            detail = str(payload)[:500]
+
+    message = f"Foundry endpoint returned HTTP {resp.status_code}"
+    if error_code:
+        message += f" ({error_code})"
+    if detail:
+        message += f": {detail}"
+    if trace_id:
+        message += f" [trace_id={trace_id}]"
+
+    raise FoundryEndpointError(
+        message,
+        request=resp.request,
+        response=resp,
+        error_code=error_code,
+        trace_id=trace_id,
+    )
+
 
 def _to_jsonable(X: Any) -> list:
     """Coerce numpy / pandas inputs to plain Python lists for JSON."""
@@ -150,6 +218,29 @@ class _FoundryBase(BaseEstimator):
                     "fit_mode='fit_with_cache' (or leave fit_mode unset)."
                 )
 
+        if (
+            self.thinking_effort is not None
+            and self.thinking_effort not in _VALID_THINKING_EFFORTS
+        ):
+            raise ValueError(
+                f"thinking_effort must be one of "
+                f"{list(_VALID_THINKING_EFFORTS)}; got {self.thinking_effort!r}."
+            )
+
+        if self.thinking_metric is not None:
+            allowed = _VALID_THINKING_METRICS.get(self._task, ())
+            if self.thinking_metric not in allowed:
+                raise ValueError(
+                    f"thinking_metric={self.thinking_metric!r} is not supported "
+                    f"for task={self._task!r}; expected one of {list(allowed)}."
+                )
+
+        if self.thinking_timeout_s is not None and self.thinking_timeout_s < 0:
+            raise ValueError(
+                f"thinking_timeout_s must be >= 0 (0 means no client-requested "
+                f"limit); got {self.thinking_timeout_s!r}."
+            )
+
     @property
     def _thinking_active(self) -> bool:
         return self.thinking_mode or self.thinking_effort is not None
@@ -186,7 +277,17 @@ class _FoundryBase(BaseEstimator):
         return cfg
 
     def _build_thinking_block(self) -> Dict[str, Any]:
-        """Top-level wire fields for thinking-mode. Empty when inactive."""
+        """Top-level wire fields for thinking-mode. Empty when inactive.
+
+        The endpoint only accepts these keys at the top level of the request
+        body — nesting them under `task_config` / `tabpfn_config` /
+        `predict_params` is rejected the same way an unknown field is.
+
+        Note that `thinking_timeout_s` is a budget the server must be able to
+        meet: a value too small for the dataset makes the request fail rather
+        than return a cheaper answer, so leave it unset (or 0) unless you
+        specifically need to bound the call.
+        """
         if not self._thinking_active:
             return {}
         block: Dict[str, Any] = {
@@ -265,7 +366,7 @@ class _FoundryBase(BaseEstimator):
             json=body,
             headers=self._headers(),
         )
-        resp.raise_for_status()
+        _raise_for_status(resp)
         payload = resp.json()
         if self._cache_active:
             self._cached_model_id = payload.get("model_id") or self._cached_model_id

--- a/tests/unit/test_foundry_estimator.py
+++ b/tests/unit/test_foundry_estimator.py
@@ -1,0 +1,198 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+#  Licensed under the Apache License, Version 2.0
+"""Unit tests for the Azure AI Foundry estimators.
+
+The endpoint validates the thinking-mode parameters server-side and answers
+an out-of-range value with an opaque HTTP 424, so these tests pin the
+client-side mirror of the accepted sets, and the error surfacing that makes
+a server-side failure reportable (`error_code` / `trace_id`).
+"""
+
+import httpx
+import numpy as np
+import pytest
+
+from tabpfn_client.foundry import (
+    FoundryEndpointError,
+    TabPFNClassifier,
+    TabPFNRegressor,
+)
+from tabpfn_client.foundry.estimator import _build_request_body, _raise_for_status
+
+
+URL = "https://example.inference.ml.azure.com/predict"
+KEY = "test-key"
+
+
+def _clf(**kwargs):
+    return TabPFNClassifier(endpoint_url=URL, api_key=KEY, **kwargs)
+
+
+def _reg(**kwargs):
+    return TabPFNRegressor(endpoint_url=URL, api_key=KEY, **kwargs)
+
+
+class TestThinkingValidation:
+    @pytest.mark.parametrize("effort", ["medium", "high"])
+    def test_accepts_supported_efforts(self, effort):
+        assert _clf(thinking_effort=effort)._build_thinking_block() == {
+            "thinking_effort": effort
+        }
+
+    @pytest.mark.parametrize("effort", ["low", "minimal", "none", "auto", "MEDIUM"])
+    def test_rejects_unsupported_efforts(self, effort):
+        # The endpoint rejects everything outside {medium, high}; fail locally
+        # rather than surfacing an opaque 424.
+        with pytest.raises(ValueError, match="thinking_effort"):
+            _clf(thinking_effort=effort)
+
+    @pytest.mark.parametrize("metric", ["accuracy", "log_loss", "balanced_accuracy"])
+    def test_accepts_classification_metrics(self, metric):
+        assert _clf(thinking_mode=True, thinking_metric=metric) is not None
+
+    @pytest.mark.parametrize("metric", ["rmse", "mse", "mae", "r2"])
+    def test_accepts_regression_metrics(self, metric):
+        assert _reg(thinking_mode=True, thinking_metric=metric) is not None
+
+    def test_rejects_metric_from_the_other_task(self):
+        with pytest.raises(ValueError, match="thinking_metric"):
+            _clf(thinking_mode=True, thinking_metric="rmse")
+        with pytest.raises(ValueError, match="thinking_metric"):
+            _reg(thinking_mode=True, thinking_metric="accuracy")
+
+    @pytest.mark.parametrize("metric", ["roc_auc", "f1", "neg_log_loss", "bogus"])
+    def test_rejects_unsupported_metrics(self, metric):
+        with pytest.raises(ValueError, match="thinking_metric"):
+            _clf(thinking_mode=True, thinking_metric=metric)
+
+    def test_rejects_negative_timeout(self):
+        with pytest.raises(ValueError, match="thinking_timeout_s"):
+            _clf(thinking_mode=True, thinking_timeout_s=-1)
+
+    def test_allows_zero_timeout(self):
+        assert _clf(thinking_mode=True, thinking_timeout_s=0) is not None
+
+    def test_thinking_mode_defaults_effort_to_medium(self):
+        assert _clf(thinking_mode=True)._build_thinking_block() == {
+            "thinking_effort": "medium"
+        }
+
+    def test_thinking_block_empty_when_inactive(self):
+        assert _clf()._build_thinking_block() == {}
+
+    def test_thinking_implies_cache_fit_mode(self):
+        assert _clf(thinking_mode=True)._effective_fit_mode == "fit_with_cache"
+        assert _clf()._effective_fit_mode == "fit_preprocessors"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"fit_mode": "fit_preprocessors", "use_kv_cache": True},
+            {"fit_mode": "fit_preprocessors", "thinking_mode": True},
+            {"fit_mode": "fit_preprocessors", "thinking_effort": "high"},
+        ],
+    )
+    def test_rejects_conflicting_fit_mode(self, kwargs):
+        with pytest.raises(ValueError, match="Conflicting settings"):
+            _clf(**kwargs)
+
+
+class TestRequestBody:
+    def test_thinking_fields_go_at_the_top_level(self):
+        # Nesting these under task_config / tabpfn_config / predict_params is
+        # rejected by the endpoint the same way an unknown field is.
+        body = _build_request_body(
+            task="classification",
+            tabpfn_config={},
+            predict_params={"output_type": "preds"},
+            X_test=[[1.0]],
+            X_train=[[0.0]],
+            y_train=[0],
+            thinking_block={"thinking_effort": "high", "thinking_timeout_s": 30.0},
+        )
+        assert body["thinking_effort"] == "high"
+        assert body["thinking_timeout_s"] == 30.0
+        assert "thinking_effort" not in body["task_config"]
+        assert "thinking_effort" not in body["task_config"]["predict_params"]
+
+    def test_y_train_is_two_dimensional_on_the_wire(self):
+        body = _build_request_body(
+            task="classification",
+            tabpfn_config={},
+            predict_params={},
+            X_test=[[1.0]],
+            X_train=[[0.0], [1.0]],
+            y_train=np.array([0, 1]),
+        )
+        assert body["y_train"] == [[0], [1]]
+
+    def test_cache_hit_sends_model_id_instead_of_training_data(self):
+        body = _build_request_body(
+            task="classification",
+            tabpfn_config={},
+            predict_params={},
+            X_test=[[1.0]],
+            X_train=[[0.0]],
+            y_train=[0],
+            cached_model_id="abc-123",
+        )
+        assert body["context"] == {"model_id": "abc-123"}
+        assert "x_train" not in body and "y_train" not in body
+
+
+class TestErrorSurfacing:
+    def _response(self, status, json_body=None, text=None):
+        request = httpx.Request("POST", URL)
+        if json_body is not None:
+            return httpx.Response(status, json=json_body, request=request)
+        return httpx.Response(status, text=text or "", request=request)
+
+    def test_passes_through_success(self):
+        assert _raise_for_status(self._response(200, {"prediction": [1]})) is None
+
+    def test_surfaces_error_code_and_trace_id(self):
+        resp = self._response(
+            424,
+            {
+                "message": "Inference failed; report the trace id to your provider.",
+                "error_code": "INTERNAL_ERROR",
+                "trace_id": "abc123",
+            },
+        )
+        with pytest.raises(FoundryEndpointError) as exc:
+            _raise_for_status(resp)
+
+        err = exc.value
+        assert err.error_code == "INTERNAL_ERROR"
+        assert err.trace_id == "abc123"
+        assert err.response.status_code == 424
+        # the trace id is what the endpoint provider needs, so it must be in
+        # the message a user actually sees
+        assert "abc123" in str(err)
+        assert "INTERNAL_ERROR" in str(err)
+        assert "424" in str(err)
+
+    def test_remains_catchable_as_httpx_error(self):
+        resp = self._response(424, {"error_code": "X", "trace_id": "t"})
+        with pytest.raises(httpx.HTTPStatusError):
+            _raise_for_status(resp)
+
+    def test_handles_non_json_error_body(self):
+        resp = self._response(401, text="key_auth_access_denied")
+        with pytest.raises(FoundryEndpointError) as exc:
+            _raise_for_status(resp)
+        assert exc.value.error_code is None
+        assert "key_auth_access_denied" in str(exc.value)
+
+
+class TestFit:
+    def test_rejects_mismatched_lengths(self):
+        with pytest.raises(ValueError, match="same number of samples"):
+            _clf().fit(np.zeros((3, 2)), np.zeros(4))
+
+    def test_fit_resets_cached_model_id(self):
+        clf = _clf(use_kv_cache=True)
+        clf.fit(np.zeros((3, 2)), np.array([0, 1, 0]))
+        clf._cached_model_id = "stale-id"
+        clf.fit(np.zeros((3, 2)), np.array([0, 1, 0]))
+        assert clf._cached_model_id is None

--- a/uv.lock
+++ b/uv.lock
@@ -1427,7 +1427,7 @@ wheels = [
 
 [[package]]
 name = "tabpfn-client"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
Introduces the Azure AI Foundry TabPFN client (`TabPFNClassifier` / `TabPFNRegressor`) with thinking-mode support and hosted-client-compatible `predict` output shapes.