### PR TITLE
Add a parquet payload option to the hosted client

### DIFF
--- a/src/tabpfn_client/hosted/estimator.py
+++ b/src/tabpfn_client/hosted/estimator.py
@@ -28,17 +28,29 @@ only sent when set; some deployments reject overrides.
 `model_id` lives on the constructor (not on `predict`) so the sklearn
 estimator contract stays intact: `predict(X)` / `predict_proba(X)` work
 with `Pipeline`, `GridSearchCV`, `cross_validate`, etc.
+
+`payload_format="parquet"` sends the datasets as multipart Parquet files
+instead of inline JSON. Encoding dominates request time on large tables,
+and Parquet also carries missing values natively, which JSON cannot.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+import io
+import json
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import httpx
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
+
+
+# Multipart form field name -> JSON body key for the same dataset.
+_JSON_DATASET_KEYS = {"x_train": "X_train", "y_train": "y_train", "x_test": "X_test"}
+
+_PARQUET_MIME = "application/vnd.apache.parquet"
 
 
 def _to_jsonable(X: Any) -> list:
@@ -50,6 +62,14 @@ def _to_jsonable(X: Any) -> list:
     if isinstance(X, list):
         return X
     return np.asarray(X).tolist()
+
+
+def _to_parquet_part(X: Any, name: str) -> Tuple[str, bytes, str]:
+    """Serialize one dataset to a multipart Parquet file part."""
+    frame = X if isinstance(X, pd.DataFrame) else pd.DataFrame(X)
+    buf = io.BytesIO()
+    frame.to_parquet(buf, index=False, compression="zstd")
+    return (f"{name}.parquet", buf.getvalue(), _PARQUET_MIME)
 
 
 class _HostedBase(BaseEstimator):
@@ -78,6 +98,7 @@ class _HostedBase(BaseEstimator):
         memory_saving_mode: Optional[bool | Literal["auto"]] = None,
         categorical_features_indices: Optional[List[int]] = None,
         timeout_s: float = 300.0,
+        payload_format: Literal["json", "parquet"] = "json",
     ):
         self.endpoint_url = endpoint_url
         self.api_key = api_key
@@ -96,6 +117,7 @@ class _HostedBase(BaseEstimator):
         self.memory_saving_mode = memory_saving_mode
         self.categorical_features_indices = categorical_features_indices
         self.timeout_s = timeout_s
+        self.payload_format = payload_format
 
     def _build_tabpfn_config(self) -> Dict[str, Any]:
         cfg: Dict[str, Any] = {
@@ -120,10 +142,9 @@ class _HostedBase(BaseEstimator):
         return cfg
 
     def _headers(self) -> Dict[str, str]:
-        headers: Dict[str, str] = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self.payload_format == "json":
+            headers["Content-Type"] = "application/json"
         # The API key is optional because some deployments do not require it
         if self.api_key is not None:
             headers["Authorization"] = f"Bearer {self.api_key}"
@@ -176,14 +197,14 @@ class _HostedBase(BaseEstimator):
         if predict_params:
             params.update(predict_params)
 
-        body: Dict[str, Any] = {
+        request: Dict[str, Any] = {
             "task_config": {
                 "task": self._TASK,
                 "tabpfn_config": self._build_tabpfn_config(),
                 "predict_params": params,
-            },
-            "X_test": _to_jsonable(X_test),
+            }
         }
+        datasets: Dict[str, Any] = {"x_test": X_test}
 
         # Precedence: a completed fit() wins over the constructor's model_id.
         # Rationale — if the caller ran fit(new_X, new_y) on an estimator that
@@ -196,19 +217,15 @@ class _HostedBase(BaseEstimator):
             y_arr = np.asarray(self.y_train_)
             if y_arr.ndim == 1:
                 y_arr = y_arr.reshape(-1, 1)
-            body["X_train"] = _to_jsonable(self.X_train_)
-            body["y_train"] = y_arr.tolist()
+            datasets["x_train"] = self.X_train_
+            datasets["y_train"] = y_arr
         elif self.model_id is not None:
-            body["context"] = {"model_id": self.model_id}
+            request["context"] = {"model_id": self.model_id}
         else:
             # Neither path available — raise the standard sklearn error.
             check_is_fitted(self, ["X_train_", "y_train_"])
 
-        resp = self._http_client().post(
-            self.endpoint_url,
-            json=body,
-            headers=self._headers(),
-        )
+        resp = self._post(request, datasets)
         resp.raise_for_status()
         payload = resp.json()
 
@@ -217,6 +234,29 @@ class _HostedBase(BaseEstimator):
             self.model_id_ = returned_id
 
         return payload
+
+    def _post(
+        self, request: Dict[str, Any], datasets: Dict[str, Any]
+    ) -> httpx.Response:
+        """POST the request, with the datasets inline or as Parquet files."""
+        if self.payload_format == "parquet":
+            return self._http_client().post(
+                self.endpoint_url,
+                data={"request": json.dumps(request)},
+                files={
+                    name: _to_parquet_part(value, name)
+                    for name, value in datasets.items()
+                },
+                headers=self._headers(),
+            )
+        body = dict(request)
+        for name, value in datasets.items():
+            body[_JSON_DATASET_KEYS[name]] = _to_jsonable(value)
+        return self._http_client().post(
+            self.endpoint_url,
+            json=body,
+            headers=self._headers(),
+        )
 
 
 class TabPFNClassifier(_HostedBase, ClassifierMixin):

--- a/tests/unit/test_hosted_estimator.py
+++ b/tests/unit/test_hosted_estimator.py
@@ -1,0 +1,158 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+#  Licensed under the Apache License, Version 2.0
+"""Unit tests for the self-hosted endpoint estimators.
+
+Cover the wire format: JSON stays the default, and `payload_format="parquet"`
+moves the datasets into multipart file parts.
+"""
+
+import io
+import json
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+import numpy as np
+import pandas as pd
+
+from tabpfn_client.hosted import TabPFNClassifier, TabPFNRegressor
+
+
+URL = "https://example.test/predict"
+
+X = pd.DataFrame({"a": [0.1, 0.2, 0.8, 0.9], "b": [1.0, np.nan, 3.0, 4.0]})
+X_COMPLETE = X.fillna(2.0)
+Y = pd.Series([0, 0, 1, 1])
+
+
+class Recorder:
+    """Captures the outgoing request and answers with a canned prediction."""
+
+    def __init__(self, prediction: Any = None, model_id: Optional[str] = None):
+        self.prediction = [[0.4, 0.6]] * 2 if prediction is None else prediction
+        self.model_id = model_id
+        self.request: Optional[httpx.Request] = None
+
+    def install(self, estimator: Any) -> None:
+        """Point the estimator's cached client at this recorder."""
+        estimator._cached_client = httpx.Client(transport=httpx.MockTransport(self))
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.request = request
+        body: Dict[str, Any] = {"prediction": self.prediction}
+        if self.model_id is not None:
+            body["model_id"] = self.model_id
+        return httpx.Response(200, json=body)
+
+    def sent(self) -> httpx.Request:
+        assert self.request is not None, "no request was sent"
+        return self.request
+
+    def content_type(self) -> str:
+        return self.sent().headers["content-type"]
+
+    def json_body(self) -> Dict[str, Any]:
+        return json.loads(self.sent().content)
+
+    def multipart(self) -> Tuple[Dict[str, Any], Dict[str, pd.DataFrame]]:
+        """The JSON `request` field and each Parquet part, by field name."""
+        boundary = self.content_type().split("boundary=")[1]
+        config: Dict[str, Any] = {}
+        frames: Dict[str, pd.DataFrame] = {}
+        for part in self.sent().content.split(f"--{boundary}".encode())[1:-1]:
+            head, payload = part.split(b"\r\n\r\n", 1)
+            name = head.decode().split('name="')[1].split('"')[0]
+            payload = payload.rstrip(b"\r\n")
+            if name == "request":
+                config = json.loads(payload)
+            else:
+                frames[name] = pd.read_parquet(io.BytesIO(payload))
+        return config, frames
+
+
+def _classifier(recorder: Recorder, **kwargs: Any) -> TabPFNClassifier:
+    model = TabPFNClassifier(endpoint_url=URL, **kwargs)
+    recorder.install(model)
+    return model
+
+
+def _regressor(recorder: Recorder, **kwargs: Any) -> TabPFNRegressor:
+    model = TabPFNRegressor(endpoint_url=URL, **kwargs)
+    recorder.install(model)
+    return model
+
+
+class TestJsonPayload:
+    def test_is_the_default(self):
+        recorder = Recorder()
+        model = _classifier(recorder)
+        model.fit(X_COMPLETE, Y)
+        model.predict_proba(X_COMPLETE.iloc[:2])
+
+        assert recorder.content_type() == "application/json"
+        body = recorder.json_body()
+        assert body["task_config"]["task"] == "classification"
+        assert len(body["X_train"]) == 4
+        # y_train on the wire is 2D.
+        assert body["y_train"] == [[0], [0], [1], [1]]
+
+
+class TestParquetPayload:
+    def test_sends_datasets_as_multipart_files(self):
+        recorder = Recorder()
+        model = _classifier(recorder, payload_format="parquet")
+        model.fit(X, Y)
+        model.predict_proba(X.iloc[:2])
+
+        assert recorder.content_type().startswith("multipart/form-data")
+        config, frames = recorder.multipart()
+        assert config["task_config"]["task"] == "classification"
+        assert set(frames) == {"x_train", "y_train", "x_test"}
+        assert frames["y_train"].shape == (4, 1)
+        assert list(frames["x_test"].columns) == ["a", "b"]
+
+    def test_carries_missing_values(self):
+        recorder = Recorder()
+        model = _classifier(recorder, payload_format="parquet")
+        model.fit(X, Y)
+        model.predict_proba(X.iloc[:2])
+
+        _, frames = recorder.multipart()
+        assert frames["x_train"]["b"].isna().sum() == 1
+
+    def test_cached_predict_omits_training_data(self):
+        recorder = Recorder()
+        model = _classifier(recorder, payload_format="parquet", model_id="abc")
+        model.predict_proba(X.iloc[:2])
+
+        config, frames = recorder.multipart()
+        assert config["context"] == {"model_id": "abc"}
+        assert set(frames) == {"x_test"}
+
+    def test_captures_the_returned_model_id(self):
+        recorder = Recorder(model_id="xyz")
+        model = _classifier(
+            recorder, payload_format="parquet", fit_mode="fit_with_cache"
+        )
+        model.fit(X, Y)
+        model.predict_proba(X.iloc[:2])
+
+        assert model.model_id_ == "xyz"
+
+    def test_regressor_round_trips(self):
+        recorder = Recorder(prediction=[1.5, 2.5])
+        model = _regressor(recorder, payload_format="parquet")
+        model.fit(X, pd.Series([1.0, 2.0, 3.0, 4.0]))
+
+        np.testing.assert_allclose(model.predict(X.iloc[:2]), [1.5, 2.5])
+        config, _ = recorder.multipart()
+        assert config["task_config"]["task"] == "regression"
+
+    def test_numpy_input_keeps_column_count(self):
+        """Integer column names are coerced by `to_parquet`, as gapi relies on."""
+        recorder = Recorder()
+        model = _classifier(recorder, payload_format="parquet")
+        model.fit(np.zeros((4, 3)), np.array([0, 0, 1, 1]))
+        model.predict_proba(np.zeros((2, 3)))
+
+        _, frames = recorder.multipart()
+        assert list(frames["x_train"].columns) == ["0", "1", "2"]


### PR DESCRIPTION
JSON encoding dominates request time on large tables. For example on a large data of 100k rows and 50 features, the JSON path is around 1.6x slower. Parquet encoding already present for the main client https://github.com/PriorLabs/tabpfn-client/blob/main/src/tabpfn_client/client.py#L147

### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*


**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
