### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.4.2"
+version = "0.5.0"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Bumps the version for the next release. `0.5.0` rather than `0.4.3`, because the default
authentication path changed and public surface was removed:

- `tabpfn_client.browser_auth` is gone as a module.
- `ServiceClient.login`, `try_browser_login` and `send_reset_password_email` are removed,
  along with most of `PromptAgent`'s surface.
- `init()` no longer prompts for credentials. Without a token it raises with instructions;
  interactive login is opt-in via `interactive_login()`.

<details>
<summary>Release check</summary>

Run against `main` before bumping:

- Unit suite: 225 passed.
- Authentication and `interactive_login()`: 13 live checks against the API, including the
  localhost-callback and paste routes driven through a pty, cache-write discipline, and the
  no-token and rejected-token error paths.
- Self-hosted client, JSON and Parquet payloads: 14 checks against a local inference
  endpoint. Predictions are bit-identical between the two formats; Parquet additionally
  carries NaN and datetime columns, which JSON rejects client-side.
- Release-readiness suite against the API: 117 passed, 3 failed. The three failures are
  KV-cached fits on model versions v2, v2.5 and v2.6 returning a worker error; they
  reproduce identically on the tree that shipped as 0.4.2, so they are unrelated to this
  release and are being followed up separately.
- Packaging: wheel and sdist build from a clean tree and install, import and authenticate
  on Python 3.10.

Two client follow-ups, neither blocking this bump:

- With `payload_format="parquet"`, fitting on a named `DataFrame` and predicting on a numpy
  array is rejected by the endpoint, because Parquet carries column names and JSON does not.
  Naming the test frame from the training frame's columns resolves it.
- A rejected `TABPFN_TOKEN` does not fall back to a cached token, although the comment in
  `_discard_token` says it should — the discard clears the options object while resolution
  reads the environment directly.

</details>