### PR TITLE
ci: add release pipeline and towncrier changelog

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -11,10 +11,15 @@ permissions: {}
 jobs:
   check:
     name: Changelog entry
+    # The release-branch exemption applies to this repository's own branches
+    # only. `head_ref` is the head branch's name wherever it lives, so a fork
+    # branch called release/v... would otherwise skip the check -- and a
+    # skipped required check reports as passing.
     if: >-
       github.event_name == 'pull_request' &&
       github.actor != 'dependabot[bot]' &&
-      !startsWith(github.head_ref, 'release/v')
+      !(github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.head_ref, 'release/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,57 @@
+name: Check Changelog
+run-name: "changelog check on ${{ github.head_ref || github.ref_name }}"
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  check:
+    name: Changelog entry
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check changelog entry
+        id: changelog_check
+        uses: scientific-python/action-towncrier-changelog@f9c7df9a9f8b55cb0c12d94d14b281e9bcd101c0 # v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_USERNAME: changelog-bot
+
+      - name: Show instructions on failure
+        if: failure() && steps.changelog_check.outcome == 'failure'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cat <<EOF
+
+          ─────────────────────────────────────────────────────────────
+          Missing changelog entry.
+
+          Add a file: changelog/${PR_NUMBER}.<category>.md
+          Categories: breaking, added, changed, fixed, deprecated
+
+          For example:
+            uvx towncrier create ${PR_NUMBER}.added.md --content "What changed, for a user"
+
+          A change that needs no entry — a version bump, a CI-only edit —
+          can carry the "no changelog needed" label instead.
+          See changelog/README.md.
+          ─────────────────────────────────────────────────────────────
+
+          EOF
+          exit 1

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   release_pr:
+    name: Open the release PR
+    if: github.repository == 'PriorLabs/tabpfn-client'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -50,6 +52,22 @@ jobs:
           }
           echo "RELEASE_BRANCH=release/v${VERSION}" >> "$GITHUB_ENV"
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      # Installed at a pinned version, and before the checkout below: from that
+      # point on the working tree holds a credential in .git/config, and
+      # nothing else may execute alongside it.
+      - name: Install towncrier
+        run: uv pip install --system 'towncrier==25.8.0'
+
       # RELEASE_BOT_TOKEN rather than GITHUB_TOKEN: a pull request opened with
       # the GITHUB_TOKEN does not start workflow runs, which would leave the
       # release PR without CI.
@@ -58,17 +76,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN }}
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.12"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install towncrier
-        run: uv pip install --system towncrier
 
       - name: Create release branch from base ref
         run: |
@@ -128,5 +135,11 @@ jobs:
             --body "Automated release PR for v${VERSION}, cut from ${BASE_REF}.
 
           Merging this tags \`v${VERSION}\` and starts the publish workflow, which
-          uploads to TestPyPI, installs from there to verify, and then waits for a
-          review on the \`pypi\` environment before touching PyPI."
+          uploads to TestPyPI, installs the result from there to verify it, and
+          then publishes to PyPI.
+
+          The PyPI step runs in the \`pypi\` environment. Whether it pauses for a
+          review depends on that environment carrying a required reviewer, which
+          is repository configuration rather than anything this workflow can
+          assert -- an environment with no protection rules publishes
+          unattended."

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -1,0 +1,132 @@
+name: Create Release PR
+run-name: "create release PR for v${{ inputs.version }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, e.g. 0.5.0 or 0.5.0rc1"
+        required: true
+      base_ref:
+        description: "Full 40-character commit SHA to release from"
+        required: true
+      base_branch:
+        description: "Branch to open the PR against"
+        required: false
+        default: "main"
+
+permissions: {}
+
+concurrency:
+  group: release-create-pr
+  cancel-in-progress: false
+
+jobs:
+  release_pr:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ inputs.version }}
+      BASE_REF: ${{ inputs.base_ref }}
+      BASE_BRANCH: ${{ inputs.base_branch }}
+    steps:
+      # Inputs reach the shell through the environment, never through ${{ }}
+      # interpolation, and every one of them is constrained here before use.
+      - name: Validate inputs
+        run: |
+          printf '%s' "$BASE_REF" | grep -Eq '^[0-9a-f]{40}$' || {
+            echo "base_ref must be a full 40-character commit SHA, got: $BASE_REF"
+            exit 1
+          }
+          printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?$' || {
+            echo "version must be a PEP 440 release or pre-release, e.g. 0.5.0 or 0.5.0rc1, got: $VERSION"
+            exit 1
+          }
+          printf '%s' "$BASE_BRANCH" | grep -Eq '^[A-Za-z0-9._/-]+$' || {
+            echo "base_branch contains unexpected characters, got: $BASE_BRANCH"
+            exit 1
+          }
+          echo "RELEASE_BRANCH=release/v${VERSION}" >> "$GITHUB_ENV"
+
+      # RELEASE_BOT_TOKEN rather than GITHUB_TOKEN: a pull request opened with
+      # the GITHUB_TOKEN does not start workflow runs, which would leave the
+      # release PR without CI.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install towncrier
+        run: uv pip install --system towncrier
+
+      - name: Create release branch from base ref
+        run: |
+          git checkout --detach "$BASE_REF"
+          git checkout -b "$RELEASE_BRANCH"
+
+      - name: Bump version in pyproject.toml
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+
+          pattern = r'(?ms)(^\[project\]\s*\n.*?^\s*version\s*=\s*")([^"]+)(")'
+          match = re.search(pattern, text)
+          if not match:
+              raise SystemExit("Could not find [project].version in pyproject.toml")
+
+          path.write_text(
+              text[: match.start(2)] + version + text[match.end(2) :], encoding="utf-8"
+          )
+          print(f"Bumped [project].version from {match.group(2)} to {version}")
+          PY
+
+      - name: Build changelog
+        run: towncrier build --version "$VERSION" --yes
+
+      - name: Commit release changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add pyproject.toml CHANGELOG.md changelog
+
+          if git diff --cached --quiet; then
+            echo "Nothing staged. Are there changelog fragments in changelog/ to release?"
+            exit 1
+          fi
+
+          git commit -m "Release v${VERSION}"
+
+      - name: Push branch
+        run: git push --set-upstream origin "$RELEASE_BRANCH"
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: |
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$RELEASE_BRANCH" \
+            --title "Release v${VERSION}" \
+            --body "Automated release PR for v${VERSION}, cut from ${BASE_REF}.
+
+          Merging this tags \`v${VERSION}\` and starts the publish workflow, which
+          uploads to TestPyPI, installs from there to verify, and then waits for a
+          review on the \`pypi\` environment before touching PyPI."

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,250 @@
+name: Release to PyPI
+run-name: "publish ${{ github.ref_name }}"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+concurrency:
+  group: release-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Read version from tag
+        id: version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?$' || {
+            echo "Tag $TAG_NAME does not carry a valid release version"
+            exit 1
+          }
+
+          if printf '%s' "$VERSION" | grep -Eq '(a|b|rc)[0-9]+$'; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Releasing $VERSION (prerelease: $PRERELEASE)"
+
+      - name: Verify tag matches pyproject.toml
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          tag_version = os.environ["VERSION"]
+          text = Path("pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(
+              r'(?ms)^\[project\]\s*\n.*?^\s*version\s*=\s*"([^"]+)"', text
+          )
+          if not match:
+              raise SystemExit("Could not find [project].version in pyproject.toml")
+
+          file_version = match.group(1).strip()
+          if tag_version != file_version:
+              raise SystemExit(
+                  f"Version mismatch: tag={tag_version} pyproject={file_version}"
+              )
+          print("Tag matches pyproject version:", tag_version)
+          PY
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Build sdist and wheel
+        run: |
+          rm -rf dist
+          uv build
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          text = Path("CHANGELOG.md").read_text(encoding="utf-8")
+
+          pattern = (
+              rf"(?ms)^##\s+\[{re.escape(version)}\]\s+-\s+"
+              rf"\d{{4}}-\d{{2}}-\d{{2}}\s*\n(.*?)(?=^##\s+\[|\Z)"
+          )
+          match = re.search(pattern, text)
+          if not match:
+              raise SystemExit(
+                  f"No changelog section for {version} in CHANGELOG.md"
+              )
+
+          Path("release_notes.md").write_text(
+              match.group(1).strip() + "\n", encoding="utf-8"
+          )
+          print("Wrote release_notes.md")
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release_notes
+          path: release_notes.md
+          retention-days: 7
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/tabpfn-client/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      # Trusted publishing over OIDC. There is no API token to leak, and the
+      # PyPI side is bound to this repository, this workflow file, and the
+      # environment named above.
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+          skip-existing: true
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Wait for TestPyPI to index the release
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl -sf "https://test.pypi.org/simple/tabpfn-client/" \
+              | grep -qF "tabpfn_client-${VERSION}.tar.gz"; then
+              echo "Indexed after $((attempt * 10))s"
+              exit 0
+            fi
+            echo "  not indexed yet (attempt ${attempt}/30)"
+            sleep 10
+          done
+          echo "Timed out after 5 minutes waiting for the TestPyPI index"
+          exit 1
+
+      - name: Install from TestPyPI and verify the version
+        run: |
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+          uv venv
+          # --refresh-package bypasses uv's HTTP cache, which setup-uv restores
+          # across runs and which otherwise serves a simple-index page predating
+          # this upload.
+          uv pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            --refresh-package tabpfn-client \
+            "tabpfn-client==${VERSION}"
+
+          uv run python - <<'PY'
+          import os
+
+          import tabpfn_client
+
+          expected = os.environ["VERSION"]
+          assert tabpfn_client.__version__ == expected, (
+              f"expected {expected!r}, got {tabpfn_client.__version__!r}"
+          )
+          print("Installed tabpfn_client.__version__ ==", tabpfn_client.__version__)
+          PY
+
+  publish-pypi:
+    needs: [build, publish-testpypi]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/tabpfn-client/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+      PRERELEASE: ${{ needs.build.outputs.prerelease }}
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          print-hash: true
+          skip-existing: true
+
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download release notes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release_notes
+          path: .
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          else
+            PRERELEASE_FLAG=""
+          fi
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release_notes.md \
+            --verify-tag \
+            $PRERELEASE_FLAG \
+            dist/*

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    name: Build distributions
+    if: github.repository == 'PriorLabs/tabpfn-client'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -74,10 +76,14 @@ jobs:
           print("Tag matches pyproject version:", tag_version)
           PY
 
+      # No cache anywhere on the release path. A restorable cache is writable
+      # by anything else that runs in this repository, and this job produces the
+      # artifact that reaches PyPI. setup-uv's default already skips the cache
+      # on tag pushes; saying so is what keeps that true.
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Build sdist and wheel
         run: |
@@ -125,6 +131,8 @@ jobs:
           retention-days: 7
 
   publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.repository == 'PriorLabs/tabpfn-client'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -133,8 +141,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      VERSION: ${{ needs.build.outputs.version }}
     steps:
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -152,11 +158,18 @@ jobs:
           print-hash: true
           skip-existing: true
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-
+  # Installing the release runs its dependencies' code, so this job holds no
+  # token at all: no OIDC, no GITHUB_TOKEN, and no cache that a later job
+  # could restore.
+  verify-testpypi:
+    name: Verify the TestPyPI release
+    if: github.repository == 'PriorLabs/tabpfn-client'
+    needs: [build, publish-testpypi]
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
       - name: Wait for TestPyPI to index the release
         run: |
           for attempt in $(seq 1 30); do
@@ -171,22 +184,44 @@ jobs:
           echo "Timed out after 5 minutes waiting for the TestPyPI index"
           exit 1
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      # TestPyPI supplies exactly one package, ours, and never a dependency:
+      # names go unclaimed on that index, and whoever claims one first decides
+      # what gets installed here.
       - name: Install from TestPyPI and verify the version
         run: |
           workdir="$(mktemp -d)"
           cd "$workdir"
           uv venv
-          # --refresh-package bypasses uv's HTTP cache, which setup-uv restores
-          # across runs and which otherwise serves a simple-index page predating
-          # this upload.
+
+          # --refresh-package bypasses uv's HTTP cache, which would otherwise
+          # serve a simple-index page predating this upload.
           uv pip install \
             --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
+            --no-deps \
             --refresh-package tabpfn-client \
             "tabpfn-client==${VERSION}"
 
-          uv run python - <<'PY'
+          .venv/bin/python - <<'PY' > requirements.txt
+          from importlib.metadata import requires
+
+          for requirement in requires("tabpfn-client") or []:
+              base, _, marker = requirement.partition(";")
+              if "extra ==" in marker:
+                  continue
+              print(base.strip())
+          PY
+
+          echo "Resolving dependencies from PyPI only:"
+          cat requirements.txt
+
+          uv pip install --index-url https://pypi.org/simple/ -r requirements.txt
+
+          VERSION="$VERSION" .venv/bin/python - <<'PY'
           import os
 
           import tabpfn_client
@@ -199,7 +234,9 @@ jobs:
           PY
 
   publish-pypi:
-    needs: [build, publish-testpypi]
+    name: Publish to PyPI
+    if: github.repository == 'PriorLabs/tabpfn-client'
+    needs: [build, verify-testpypi]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -217,14 +254,18 @@ jobs:
           name: dist
           path: dist/
 
+      # No skip-existing here: on the real index a version that is already
+      # present means the release is not what this run built, and the run must
+      # stop rather than go on to cut a GitHub release for it.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
-          skip-existing: true
 
       - name: Checkout tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download release notes
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -1,0 +1,76 @@
+name: Tag Release Branch on PR Merge
+run-name: "tag from ${{ github.event.pull_request.head.ref }}"
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  tag:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    env:
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+    steps:
+      # RELEASE_BOT_TOKEN rather than GITHUB_TOKEN: a tag pushed with the
+      # GITHUB_TOKEN does not start workflow runs, so release-publish.yml
+      # would never fire.
+      - name: Checkout merge commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Read version from pyproject.toml
+        run: |
+          python - <<'PY' >> "$GITHUB_ENV"
+          import re
+          from pathlib import Path
+
+          text = Path("pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(
+              r'(?ms)^\[project\]\s*\n.*?^\s*version\s*=\s*"([^"]+)"', text
+          )
+          if not match:
+              raise SystemExit("Could not find [project].version in pyproject.toml")
+
+          version = match.group(1).strip()
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?", version):
+              raise SystemExit(f"Version in pyproject.toml is not a valid release: {version}")
+          print(f"VERSION={version}")
+          PY
+
+      # The branch name is the human intent; pyproject.toml is what gets built.
+      # A mismatch means the release PR was edited after it was opened.
+      - name: Verify the branch name agrees with pyproject.toml
+        run: |
+          if [ "$HEAD_REF" != "release/v${VERSION}" ]; then
+            echo "Branch $HEAD_REF does not match pyproject version $VERSION"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          TAG="v${VERSION}"
+          git fetch --tags
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, nothing to do."
+            exit 0
+          fi
+
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -7,10 +7,20 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-tag-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 jobs:
   tag:
+    name: Tag the release
+    # The branch condition alone would also match a fork branch named
+    # release/v..., and the workflow file itself comes from the PR's merge
+    # commit. Forks never enter this job.
     if: |
+      github.repository == 'PriorLabs/tabpfn-client' &&
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     environment: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/changelog/352.added.md
+++ b/changelog/352.added.md
@@ -1,0 +1,1 @@
+Added `interactive_login()`, an opt-in browser or terminal login that verifies the resulting API key and caches it for later runs.

--- a/changelog/352.breaking.md
+++ b/changelog/352.breaking.md
@@ -1,0 +1,1 @@
+Authentication is token-based by default. `init()` never prompts: it reads `TABPFN_TOKEN`, a token set with `set_access_token()`, or one cached by a previous login, and raises with instructions when none is available. `tabpfn_client.browser_auth` and the login helpers on `ServiceClient` are removed.

--- a/changelog/359.added.md
+++ b/changelog/359.added.md
@@ -1,0 +1,1 @@
+The self-hosted client accepts `payload_format="parquet"`, which sends datasets as Parquet files instead of inline JSON. Encoding is faster on large tables, and missing values and datetimes survive the round trip, which JSON cannot represent.

--- a/changelog/361.added.md
+++ b/changelog/361.added.md
@@ -1,0 +1,1 @@
+`tabpfn_client.__version__` reports the installed package version.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,35 @@
+# Changelog Fragments
+
+This directory holds changelog "fragments" — small files describing the
+user-visible change in each PR. At release time the `release-create-pr.yml`
+workflow runs `towncrier build`, which assembles the fragments into
+`CHANGELOG.md` and deletes them from here.
+
+## How to add an entry
+
+Create a file named `<PR_NUMBER>.<category>.md` containing one short,
+user-facing sentence.
+
+```bash
+# Recommended — validates the category
+uvx towncrier create 361.added.md --content "Support Parquet payloads in the hosted client"
+
+# Or write the file directly
+echo "Support Parquet payloads in the hosted client" > changelog/361.added.md
+```
+
+Write for someone reading release notes, not for a reviewer reading the diff:
+say what changed for the user, not which functions moved.
+
+## Categories
+
+| Filename suffix | Section | When to use |
+|---|---|---|
+| `<PR>.breaking.md` | Breaking Changes | Removed or renamed public API, changed default behaviour |
+| `<PR>.added.md` | Added | New features |
+| `<PR>.changed.md` | Changed | Changes to existing behaviour |
+| `<PR>.fixed.md` | Fixed | Bug fixes |
+| `<PR>.deprecated.md` | Deprecated | Features scheduled for removal |
+
+A PR that needs no entry — a version bump, a CI-only change — can carry the
+`no changelog needed` label instead, which satisfies `check-changelog.yml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,43 @@ dev = [
     "licensecheck==2025.1.0",
     "basedpyright~=1.39.9"
 ]
+
+[tool.changelog-bot.towncrier_changelog]
+enabled = true
+changelog_skip_label = "no changelog needed"
+
+[tool.towncrier]
+directory = "changelog"
+filename = "CHANGELOG.md"
+start_string = "## [Unreleased]\n"
+title_format = "## [{version}] - {project_date}"
+issue_format = "[#{issue}](https://github.com/PriorLabs/tabpfn-client/pull/{issue})"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.section]]
+path = ""
+name = ""

--- a/src/tabpfn_client/__init__.py
+++ b/src/tabpfn_client/__init__.py
@@ -1,6 +1,8 @@
 #  Copyright (c) Prior Labs GmbH 2025.
 #  Licensed under the Apache License, Version 2.0
 
+from importlib.metadata import PackageNotFoundError, version
+
 from tabpfn_client.config import (
     init,
     reset,
@@ -12,7 +14,13 @@ from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
 from tabpfn_client.interactive_auth import InteractiveLoginError, interactive_login
 from tabpfn_client.service_wrapper import UserDataClient
 
+try:
+    __version__ = version("tabpfn-client")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"
+
 __all__ = [
+    "__version__",
     "init",
     "reset",
     "TabPFNClassifier",


### PR DESCRIPTION
AI;DR: adding release pipelines following our other repositories including TabPFN, tabpfn-time-series, etc.

<details>
Adds the release pipeline this repo has been missing, matching the shape used in the other
public repos, plus towncrier changelogs so every release gets real notes.

## Flow

| Workflow | Trigger | Does |
|---|---|---|
| `release-create-pr.yml` | manual dispatch (`version`, `base_ref`) | bumps `[project].version`, runs `towncrier build`, opens a `Release vX.Y.Z` PR |
| `release-tag-on-merge.yml` | merge of a `release/v*` branch | reads the version back out of `pyproject.toml` and pushes tag `vX.Y.Z` |
| `release-publish.yml` | `push` of a `v*` tag | verifies tag == pyproject, builds, TestPyPI → install-verify → PyPI → GitHub release |
| `check-changelog.yml` | every PR | requires a `changelog/<PR>.<category>.md` fragment or the `no changelog needed` label |

Publishing to PyPI sits behind the `pypi` environment, so it waits for a review before
anything reaches the real index. TestPyPI runs unguarded ahead of it, and the release is
installed back out of TestPyPI and checked before the gate is reached.

## Differences from the sibling repos

These are deliberate rather than drift:

- **Every action pinned by commit SHA**, including `pypa/gh-action-pypi-publish`. Two of the
  sibling repos carry a comment saying that action cannot be SHA-pinned because it resolves a
  Docker image per ref. That is no longer true — it has been pinned at `dc37677b` elsewhere
  since 2026-07-30 and has published several releases through it. Every SHA here was checked
  against its tag via the API rather than copied on trust. Dependabot already tracks
  `github-actions` weekly, so the pins stay current.
- **No `${{ }}` interpolation inside `run:` blocks.** Dispatch inputs and PR head refs reach
  the shell through `env:` and are quoted, and each is validated against a pattern before
  first use. Splicing them directly into a script is a template-injection path.
- **`permissions: {}` at workflow level**, granted per job — the publish job is the only one
  that gets `contents: write`.
- **`--prerelease` on the GitHub release** when the version is a PEP 440 pre-release, so an
  rc does not show up as the latest release.
- **The release PR is opened with `RELEASE_BOT_TOKEN`.** A PR opened with the `GITHUB_TOKEN`
  does not start workflow runs, which would leave the release PR with no CI at all.
- `--verify-tag` on release creation, `persist-credentials: false` on checkouts that do not
  push, and a `concurrency` group per tag.

## Also here

- `tabpfn_client.__version__`, resolved from installed package metadata. The publish job
  installs from TestPyPI and asserts the version matches what it built; there was nothing to
  assert against before.
- Retroactive changelog fragments for #352 and #359, which merged before this existed. Without
  them the first `towncrier build` would find nothing and the release workflow would stop.
- `CHANGELOG.md` seeded with an `## [Unreleased]` heading, and `changelog/README.md`
  documenting how to add a fragment.

## Setup this needs before a release can run

1. Trusted publishers on PyPI and TestPyPI for `tabpfn-client` — repo `PriorLabs/tabpfn-client`,
   workflow `release-publish.yml`, environments `pypi` and `testpypi`. No API token is used.
2. Environments `release`, `testpypi` and `pypi`, with a required reviewer on `pypi`.
3. `RELEASE_BOT_TOKEN`, a fine-grained PAT scoped to this repo with `contents: write` and
   `pull-requests: write`. A tag pushed with the `GITHUB_TOKEN` does not start a workflow run,
   so without it the publish workflow never fires.

Verified locally: `actionlint` is clean on all four workflows, `towncrier build` produces the
expected `CHANGELOG.md` from the seeded fragments, the notes-extraction and version regexes
were run against the real files, and the unit suite still passes.
</details>