### PR TITLE
Release v0.5.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0rc1] - 2026-08-26
+
+### Breaking Changes
+
+- Authentication is token-based by default. `init()` never prompts: it reads `TABPFN_TOKEN`, a token set with `set_access_token()`, or one cached by a previous login, and raises with instructions when none is available. `tabpfn_client.browser_auth` and the login helpers on `ServiceClient` are removed. ([#352](https://github.com/PriorLabs/tabpfn-client/pull/352))
+
+### Added
+
+- Added `interactive_login()`, an opt-in browser or terminal login that verifies the resulting API key and caches it for later runs. ([#352](https://github.com/PriorLabs/tabpfn-client/pull/352))
+- The self-hosted client accepts `payload_format="parquet"`, which sends datasets as Parquet files instead of inline JSON. Encoding is faster on large tables, and missing values and datetimes survive the round trip, which JSON cannot represent. ([#359](https://github.com/PriorLabs/tabpfn-client/pull/359))
+- `tabpfn_client.__version__` reports the installed package version. ([#361](https://github.com/PriorLabs/tabpfn-client/pull/361))

--- a/changelog/352.added.md
+++ b/changelog/352.added.md
@@ -1,1 +1,0 @@
-Added `interactive_login()`, an opt-in browser or terminal login that verifies the resulting API key and caches it for later runs.

--- a/changelog/352.breaking.md
+++ b/changelog/352.breaking.md
@@ -1,1 +1,0 @@
-Authentication is token-based by default. `init()` never prompts: it reads `TABPFN_TOKEN`, a token set with `set_access_token()`, or one cached by a previous login, and raises with instructions when none is available. `tabpfn_client.browser_auth` and the login helpers on `ServiceClient` are removed.

--- a/changelog/359.added.md
+++ b/changelog/359.added.md
@@ -1,1 +1,0 @@
-The self-hosted client accepts `payload_format="parquet"`, which sends datasets as Parquet files instead of inline JSON. Encoding is faster on large tables, and missing values and datetimes survive the round trip, which JSON cannot represent.

--- a/changelog/361.added.md
+++ b/changelog/361.added.md
@@ -1,1 +1,0 @@
-`tabpfn_client.__version__` reports the installed package version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.5.0"
+version = "0.5.0rc1"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Automated release PR for v0.5.0rc1, cut from a9c38ac7e911d42099bcbdf018e62a2e703fd39f.

Merging this tags `v0.5.0rc1` and starts the publish workflow, which
uploads to TestPyPI, installs the result from there to verify it, and
then publishes to PyPI.

The PyPI step runs in the `pypi` environment. Whether it pauses for a
review depends on that environment carrying a required reviewer, which
is repository configuration rather than anything this workflow can
assert -- an environment with no protection rules publishes
unattended.