### PR TITLE
fix(ci): check out before downloading release artifacts

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -248,6 +248,13 @@ jobs:
       VERSION: ${{ needs.build.outputs.version }}
       PRERELEASE: ${{ needs.build.outputs.prerelease }}
     steps:
+      # Checkout comes first: it cleans the workspace, so anything downloaded
+      # ahead of it is deleted before the release can be attached.
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -261,11 +268,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
-
-      - name: Checkout tag
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
 
       - name: Download release notes
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
The `v0.5.0rc1` run published to PyPI successfully and then failed on its
last step with `no matches found for dist/*`, so no GitHub release was created.

`actions/checkout` defaults to `clean: true`, which runs `git clean -ffdx`.
In `publish-pypi` it ran *after* the distributions were downloaded, so it
deleted the untracked `dist/` directory before `gh release create` could
attach it:

1. `Download distributions` → `dist/`
2. `Publish to PyPI` → succeeded, package is live
3. `Checkout tag` → wipes `dist/`
4. `Create GitHub release … dist/*` → nothing to attach

Checkout now runs first, so both artifact downloads land after it. `build`
already had this order; `publish-testpypi` and `verify-testpypi` never check
out, so this was the only affected job.

The upload itself was never at fault — `0.5.0rc1` is on PyPI with valid
attestations (`/integrity/…/provenance` returns 200), which confirms trusted
publishing works end to end on both indexes.

### Note on v0.5.0rc1

Its GitHub release is still missing. Re-running the job is not an option:
`Publish to PyPI` deliberately omits `skip-existing`, so it would fail on the
already-uploaded files. Either leave the rc as-is or create the release by
hand from the run's artifacts.