### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-26
+
+No significant changes.
+
+
 ## [0.5.0rc1] - 2026-08-26
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.5.0rc1"
+version = "0.5.0"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Automated release PR for v0.5.0, cut from a0a782a2b64341af431d5b3405742b71ab6b7295.

Merging this tags `v0.5.0` and starts the publish workflow, which
uploads to TestPyPI, installs the result from there to verify it, and
then publishes to PyPI.

The PyPI step runs in the `pypi` environment. Whether it pauses for a
review depends on that environment carrying a required reviewer, which
is repository configuration rather than anything this workflow can
assert -- an environment with no protection rules publishes
unattended.