### PR TITLE
fix(ci): retry index reads, and smoke test the real PyPI release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -242,8 +242,108 @@ jobs:
       name: pypi
       url: https://pypi.org/project/tabpfn-client/${{ needs.build.outputs.version }}/
     permissions:
-      contents: write
+      contents: read
       id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      # No skip-existing here: on the real index a version that is already
+      # present means the release is not what this run built, and the run must
+      # stop rather than go on to cut a GitHub release for it.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          print-hash: true
+
+  # The index users actually install from, exercised the way they install from
+  # it: a plain `pip install tabpfn-client==<version>` resolving every
+  # dependency from PyPI. Nothing can be unpublished by the time this runs, so
+  # a failure here is a signal to yank, not a gate -- but it is the difference
+  # between finding out now and finding out from a bug report.
+  #
+  # Installing runs the dependencies' own code, so this job holds no token:
+  # no OIDC, no GITHUB_TOKEN, and no cache a later job could restore.
+  verify-pypi:
+    name: Verify the PyPI release
+    if: github.repository == 'PriorLabs/tabpfn-client'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Install from PyPI and smoke test
+        run: |
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+          uv venv
+
+          # Same retry as the TestPyPI check: a just-uploaded file is not
+          # immediately consistent across the index's caches.
+          for attempt in $(seq 1 30); do
+            if uv pip install \
+              --refresh-package tabpfn-client \
+              "tabpfn-client==${VERSION}"; then
+              echo "Installed on attempt ${attempt}"
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "tabpfn-client==${VERSION} never became installable from PyPI"
+              exit 1
+            fi
+            echo "  not installable yet (attempt ${attempt}/30), retrying"
+            sleep 10
+          done
+
+          VERSION="$VERSION" .venv/bin/python - <<'PY'
+          import os
+
+          import tabpfn_client
+          from tabpfn_client import TabPFNClassifier, TabPFNRegressor
+
+          expected = os.environ["VERSION"]
+          assert tabpfn_client.__version__ == expected, (
+              f"expected {expected!r}, got {tabpfn_client.__version__!r}"
+          )
+
+          # The documented surface, so a packaging change that drops a module
+          # fails here rather than for a user.
+          for name in (
+              "init",
+              "reset",
+              "get_access_token",
+              "set_access_token",
+              "get_api_usage",
+              "interactive_login",
+              "TabPFNClassifier",
+              "TabPFNRegressor",
+              "UserDataClient",
+          ):
+              assert hasattr(tabpfn_client, name), f"missing from public API: {name}"
+
+          # Constructing an estimator touches no network and no credentials.
+          TabPFNClassifier()
+          TabPFNRegressor()
+
+          print("Smoke test passed for", tabpfn_client.__version__)
+          PY
+
+  github-release:
+    name: Create the GitHub release
+    if: github.repository == 'PriorLabs/tabpfn-client'
+    needs: [build, verify-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERSION: ${{ needs.build.outputs.version }}
       PRERELEASE: ${{ needs.build.outputs.prerelease }}
@@ -260,14 +360,6 @@ jobs:
         with:
           name: dist
           path: dist/
-
-      # No skip-existing here: on the real index a version that is already
-      # present means the release is not what this run built, and the run must
-      # stop rather than go on to cut a GitHub release for it.
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          print-hash: true
 
       - name: Download release notes
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -170,20 +170,6 @@ jobs:
     env:
       VERSION: ${{ needs.build.outputs.version }}
     steps:
-      - name: Wait for TestPyPI to index the release
-        run: |
-          for attempt in $(seq 1 30); do
-            if curl -sf "https://test.pypi.org/simple/tabpfn-client/" \
-              | grep -qF "tabpfn_client-${VERSION}.tar.gz"; then
-              echo "Indexed after $((attempt * 10))s"
-              exit 0
-            fi
-            echo "  not indexed yet (attempt ${attempt}/30)"
-            sleep 10
-          done
-          echo "Timed out after 5 minutes waiting for the TestPyPI index"
-          exit 1
-
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -198,13 +184,27 @@ jobs:
           cd "$workdir"
           uv venv
 
-          # --refresh-package bypasses uv's HTTP cache, which would otherwise
-          # serve a simple-index page predating this upload.
-          uv pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --no-deps \
-            --refresh-package tabpfn-client \
-            "tabpfn-client==${VERSION}"
+          # Retry rather than probe the index first: a probe and uv's own
+          # resolution are separate requests, and TestPyPI can answer them from
+          # different caches, so a probe that succeeds proves nothing about the
+          # request that follows it. --refresh-package covers uv's local cache;
+          # the loop covers the rest.
+          for attempt in $(seq 1 30); do
+            if uv pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --no-deps \
+              --refresh-package tabpfn-client \
+              "tabpfn-client==${VERSION}"; then
+              echo "Installed on attempt ${attempt}"
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "tabpfn-client==${VERSION} never became installable from TestPyPI"
+              exit 1
+            fi
+            echo "  not installable yet (attempt ${attempt}/30), retrying"
+            sleep 10
+          done
 
           .venv/bin/python - <<'PY' > requirements.txt
           from importlib.metadata import requires


### PR DESCRIPTION
Two fixes to the release pipeline, both from the `v0.5.0` run.

## 1. Retry the install instead of probing the index

`verify-testpypi` failed:

```
Indexed after 20s                       # 12:24:02
× No solution found ... no version of tabpfn-client==0.5.0   # 12:24:03
```

One second apart. The probe and uv's resolution are separate HTTP requests,
and the index can answer them from different caches, so a probe that succeeds
proves nothing about the request after it. `--refresh-package` clears uv's
*local* cache, not the CDN's.

Verified transient — the exact command succeeds unchanged now. The probe is
gone; the install itself retries, on the same 30 × 10s budget. Both loop
branches were checked under `bash -e`: it breaks on a late success and exits 1
when attempts run out.

## 2. Smoke test the real PyPI release

TestPyPI got a full install-and-verify. The index users actually install from
got none — a malformed wheel or partial upload would have reached a user
before it reached us.

`publish-pypi` is split into three jobs:

| job | does | holds |
| --- | --- | --- |
| `publish-pypi` | uploads | OIDC token |
| `verify-pypi` | `pip install tabpfn-client==<version>` from PyPI, all deps from PyPI, import, check public surface, construct an estimator | **nothing** |
| `github-release` | cuts the release | `contents: write` |

The release is now only cut if the published artifact is actually installable.

`verify-pypi` holds no token, because installing executes the dependencies'
own code — the same reasoning already applied to `verify-testpypi`. It installs
with no `--no-deps` and no index pinning, so it exercises exactly what a user
runs.

Nothing can be unpublished by the time it runs, so a failure is a signal to
yank rather than a gate. It is still the difference between finding out during
the release and finding out from a bug report.

Verified by running the smoke test against the published `0.5.0rc1` on PyPI:
it passes, and it fails as intended on a version mismatch or a missing
public attribute.

## State of v0.5.0

Tag exists, TestPyPI has it, PyPI does not, no GitHub release — `publish-pypi`
was correctly skipped. Since tag-triggered runs use the workflow file from the
tagged commit, `v0.5.0` needs re-tagging onto a commit containing these fixes;
re-running the existing run would replay the old file.