### PR TITLE
Move away from ux.priorlabs.ai to platform.priorlabs.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Choose the right TabPFN implementation for your needs:
 - **TabPFN Client (this repo)**: Easy-to-use API client for cloud-based inference
 - **[TabPFN Extensions](https://github.com/priorlabs/tabpfn-extensions)**: Community extensions and integrations
 - **[TabPFN](https://github.com/priorlabs/tabpfn)**: Core implementation for local deployment and research
-- **[TabPFN UX](https://ux.priorlabs.ai)**: No-code TabPFN usage
+- **[TabPFN UX](https://platform.priorlabs.ai)**: No-code TabPFN usage
 
 ## Quick Start
 
@@ -46,7 +46,7 @@ pip install --upgrade tabpfn-client
 ### Basic Usage
 
 Set a token first — `fit()` raises without one and never prompts. Generate it at
-[ux.priorlabs.ai/account/api-keys](https://ux.priorlabs.ai/account/api-keys):
+[platform.priorlabs.ai/account/api-keys](https://platform.priorlabs.ai/account/api-keys):
 
 ```bash
 export TABPFN_TOKEN="<your-token>"
@@ -106,7 +106,7 @@ Notes:
 - Thinking mode is only supported on v3 models. Leave `model_path` at its default (`"auto"`, which lets the server pick the latest default — currently a v3 model) or set it explicitly to a v3 model. Combining thinking with a v2 or v2.5 `model_path` raises `ValueError` client-side.
 - `thinking_timeout_s` and `thinking_metric` are only consulted when thinking is enabled; passing them without `thinking_mode=True` or `thinking_effort=...` raises `ValueError`.
 - Thinking-mode fits take longer than regular fits (often several minutes).
-- Thinking-mode fits draw from a **separate, smaller budget** than regular fits — they do not count against your regular prediction allowance, and you cannot use your regular allowance for them. The number of thinking-mode fits you can run per day is limited. If you need more capacity, request an increase via [ux.priorlabs.ai](https://ux.priorlabs.ai).
+- Thinking-mode fits draw from a **separate, smaller budget** than regular fits — they do not count against your regular prediction allowance, and you cannot use your regular allowance for them. The number of thinking-mode fits you can run per day is limited. If you need more capacity, request an increase via [platform.priorlabs.ai](https://platform.priorlabs.ai).
 
 ## KV Cache
 
@@ -139,7 +139,7 @@ Notes:
 ## Authentication
 
 Authentication is token-based. Generate a token at
-[ux.priorlabs.ai/account/api-keys](https://ux.priorlabs.ai/account/api-keys), then supply it
+[platform.priorlabs.ai/account/api-keys](https://platform.priorlabs.ai/account/api-keys), then supply it
 in one of two ways.
 
 Via the environment, which needs no code changes:
@@ -308,7 +308,7 @@ We're building the future of tabular machine learning and would love your involv
 
 ### API Cost Calculation
 
-Each API request consumes usage credits; the cost grows with the number of rows and columns in your dataset. You can check your current usage at [ux.priorlabs.ai/account/usage](https://ux.priorlabs.ai/account/usage).
+Each API request consumes usage credits; the cost grows with the number of rows and columns in your dataset. You can check your current usage at [platform.priorlabs.ai/account/usage](https://platform.priorlabs.ai/account/usage).
 
 ### Monitoring Usage
 

--- a/changelog/368.changed.md
+++ b/changelog/368.changed.md
@@ -1,0 +1,1 @@
+TabPFN Console URL moved from `ux.priorlabs.ai` to `platform.priorlabs.ai` (the old host continues to redirect).

--- a/src/tabpfn_client/config.py
+++ b/src/tabpfn_client/config.py
@@ -40,7 +40,7 @@ def init(use_server=True):
     token cached by an earlier `interactive_login()`. If none is available this
     raises, explaining how to obtain one -- it will not prompt.
 
-    Generate a token at https://ux.priorlabs.ai/account/api-keys, or call
+    Generate a token at https://platform.priorlabs.ai/account/api-keys, or call
     `tabpfn_client.interactive_login()` to log in through the browser.
 
     :param use_server: Whether to use the TabPFN cloud service. Currently, only
@@ -138,7 +138,7 @@ def set_access_token(access_token: str):
     Use this in non-interactive environments (e.g. CI/CD, notebooks) as an
     alternative to the TABPFN_TOKEN environment variable.
 
-    Generate a token at https://ux.priorlabs.ai/account/api-keys
+    Generate a token at https://platform.priorlabs.ai/account/api-keys
 
     :param access_token: A valid TabPFN access token string.
     """

--- a/src/tabpfn_client/constants.py
+++ b/src/tabpfn_client/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 CACHE_DIR = Path(__file__).parent.resolve() / ".tabpfn"
 
 URL_TABPFN_CLIENT_GITHUB_ISSUES = "https://github.com/priorlabs/tabpfn-client/issues"
-URL_PRIOR_LABS_API_KEYS = "https://ux.priorlabs.ai/account/api-keys"
+URL_PRIOR_LABS_API_KEYS = "https://platform.priorlabs.ai/account/api-keys"
 URL_PRIOR_LABS_TERMS_AND_CONDITIONS = (
     "https://priorlabs.ai/general-terms-and-conditions"
 )

--- a/src/tabpfn_client/server_config.yaml
+++ b/src/tabpfn_client/server_config.yaml
@@ -8,7 +8,7 @@ protocol: "https"
 host: "api.priorlabs.ai"
 port: "443"
 
-gui_url: "https://ux.priorlabs.ai"
+gui_url: "https://platform.priorlabs.ai"
 endpoints:
   root:
     path: "/"

--- a/tests/unit/test_interactive_auth.py
+++ b/tests/unit/test_interactive_auth.py
@@ -289,7 +289,7 @@ class TestReviewFindings(unittest.TestCase):
         auth_event = threading.Event()
         received: list = [None]
         httpd, _ = interactive_auth._create_callback_server(
-            "https://ux.priorlabs.ai", auth_event, received
+            "https://platform.priorlabs.ai", auth_event, received
         )
         try:
             self.assertEqual("127.0.0.1", httpd.socket.getsockname()[0])
@@ -365,6 +365,6 @@ class TestReviewFindings(unittest.TestCase):
         with patch.object(interactive_auth.webbrowser, "open", return_value=False):
             with patch.object(interactive_auth, "_poll_for_token", return_value="tok"):
                 with patch("sys.stdout", new=io.StringIO()) as fake_out:
-                    interactive_auth._browser_login("https://ux.priorlabs.ai", 1.0)
+                    interactive_auth._browser_login("https://platform.priorlabs.ai", 1.0)
 
         self.assertIn("Could not open a browser", fake_out.getvalue())

--- a/tests/unit/test_interactive_auth.py
+++ b/tests/unit/test_interactive_auth.py
@@ -365,6 +365,8 @@ class TestReviewFindings(unittest.TestCase):
         with patch.object(interactive_auth.webbrowser, "open", return_value=False):
             with patch.object(interactive_auth, "_poll_for_token", return_value="tok"):
                 with patch("sys.stdout", new=io.StringIO()) as fake_out:
-                    interactive_auth._browser_login("https://platform.priorlabs.ai", 1.0)
+                    interactive_auth._browser_login(
+                        "https://platform.priorlabs.ai", 1.0
+                    )
 
         self.assertIn("Could not open a browser", fake_out.getvalue())


### PR DESCRIPTION
### Change Description

- Migrate from ux.priorlabs.ai to platform.priorlabs.ai
- The migration itself is not breaking as we will continue redirecting from ux.* to platform.*
