### PR TITLE
Add `v3.5_default` model alias

### DIFF
--- a/changelog/374.added.md
+++ b/changelog/374.added.md
@@ -1,0 +1,1 @@
+`TabPFNClassifier` and `TabPFNRegressor` accept `model_path="v3.5_default"` (and `create_default_for_version(ModelVersion.V3_5)`) to request the TabPFN 3.5 pre-release on accounts that have access to it.

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -58,12 +58,14 @@ class AsyncSettings(BaseModel):
 class ClassifierOutputType(str, Enum):
     PROBAS = "probas"
     PREDS = "preds"
+    TOP_K = "top_k"
 
 
 class ClassifierPredictParams(BaseModel):
     output_type: (
         Annotated[ClassifierOutputType | UnknownEnum, Field(union_mode="left_to_right")] | None
     ) = None
+    top_k: int | None = None
 
 
 class FitMode(str, Enum):
@@ -108,9 +110,12 @@ class ClassifierFitTaskConfig(BaseModel):
 class ClassifierMetadata(BaseModel):
     test_set_num_rows: int
     test_set_num_cols: int
+    n_estimators: int | None = None
     task: Literal[PredictionTask.CLASSIFICATION] = PredictionTask.CLASSIFICATION
     package_version: str
     tabpfn_config: ClassifierTabPFNConfig
+    classes: list[str | int | float | bool] | None = None
+    top_k: int | None = None
 
 
 class FileInfo(BaseModel):
@@ -206,6 +211,7 @@ class RegressorFitTaskConfig(BaseModel):
 class RegressorMetadata(BaseModel):
     test_set_num_rows: int
     test_set_num_cols: int
+    n_estimators: int | None = None
     task: Literal[PredictionTask.REGRESSION] = PredictionTask.REGRESSION
     package_version: str
     tabpfn_config: RegressorTabPFNConfig

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -58,14 +58,12 @@ class AsyncSettings(BaseModel):
 class ClassifierOutputType(str, Enum):
     PROBAS = "probas"
     PREDS = "preds"
-    TOP_K = "top_k"
 
 
 class ClassifierPredictParams(BaseModel):
     output_type: (
         Annotated[ClassifierOutputType | UnknownEnum, Field(union_mode="left_to_right")] | None
     ) = None
-    top_k: int | None = None
 
 
 class FitMode(str, Enum):
@@ -110,12 +108,9 @@ class ClassifierFitTaskConfig(BaseModel):
 class ClassifierMetadata(BaseModel):
     test_set_num_rows: int
     test_set_num_cols: int
-    n_estimators: int | None = None
     task: Literal[PredictionTask.CLASSIFICATION] = PredictionTask.CLASSIFICATION
     package_version: str
     tabpfn_config: ClassifierTabPFNConfig
-    classes: list[str | int | float | bool] | None = None
-    top_k: int | None = None
 
 
 class FileInfo(BaseModel):
@@ -211,7 +206,6 @@ class RegressorFitTaskConfig(BaseModel):
 class RegressorMetadata(BaseModel):
     test_set_num_rows: int
     test_set_num_cols: int
-    n_estimators: int | None = None
     task: Literal[PredictionTask.REGRESSION] = PredictionTask.REGRESSION
     package_version: str
     tabpfn_config: RegressorTabPFNConfig

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -111,6 +111,7 @@ class ClassifierMetadata(BaseModel):
     task: Literal[PredictionTask.CLASSIFICATION] = PredictionTask.CLASSIFICATION
     package_version: str
     tabpfn_config: ClassifierTabPFNConfig
+    classes: list[str | int | float | bool] | None = None
 
 
 class FileInfo(BaseModel):

--- a/src/tabpfn_client/api_models.py
+++ b/src/tabpfn_client/api_models.py
@@ -156,6 +156,7 @@ class ModelVersion(str, Enum):
     V2_5 = "v2.5"
     V2_6 = "v2.6"
     V3 = "v3"
+    V3_5 = "v3.5"
 
 
 class RegressorOutputType(str, Enum):

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -89,7 +89,7 @@ class TabPFNModelSelection:
         Any kwargs will override the default settings, except for `model_path`.
         """
         try:
-            ModelVersion(version)
+            version = ModelVersion(version)
         except ValueError:
             raise ValueError(
                 f"Invalid model version: {version}. "

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -103,7 +103,7 @@ class TabPFNModelSelection:
 class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
         # Downstream packages (e.g. tabpfn-time-series) read this list in order
-        # to parse model names by substring, so must precede "v2.5_default" (its substring).
+        # to parse model names by substring, so "v2.5_default-2" must precede "v2.5_default".
         "v2.5_default-2",
         *_DEFAULT_MODEL_NAMES,
         "v2.5_large-features-L",

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -83,7 +83,9 @@ class TabPFNModelSelection:
         return cls._AVAILABLE_MODELS
 
     @classmethod
-    def create_default_for_version(cls, version: ModelVersion | str, **overrides) -> Self:
+    def create_default_for_version(
+        cls, version: ModelVersion | str, **overrides
+    ) -> Self:
         """Construct an estimator that uses the given version of the model.
 
         Any kwargs will override the default settings, except for `model_path`.

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -59,11 +59,13 @@ logger = logging.getLogger(__name__)
 V_2_5_IDENTIFIER = "v2.5"
 V_2_6_IDENTIFIER = "v2.6"
 V_3_IDENTIFIER = "v3"
+V_3_5_IDENTIFIER = "v3.5"
 
 DEFAULT_V2_MODEL_PATH = "v2_default"
 DEFAULT_V2_5_MODEL_PATH = "v2.5_default"
 DEFAULT_V2_6_MODEL_PATH = "v2.6_default"
 DEFAULT_V3_MODEL_PATH = "v3_default"
+DEFAULT_V3_5_MODEL_PATH = "v3.5_default"
 
 # Sentinel values for `model_path` that defer model selection to the server.
 # `None` means the caller didn't pick a model; "auto" is the canonical name
@@ -113,6 +115,10 @@ class TabPFNModelSelection:
         # `None` is one of the auto aliases handled above, so the remainder is a
         # concrete model name; assert it to narrow `str | None` -> `str`.
         assert model_name is not None
+        # "v3" is a prefix of "v3.5", so the longer identifier has to be
+        # matched first or every v3.5 name would be filed under v3.
+        if V_3_5_IDENTIFIER in model_name:
+            return f"tabpfn-{V_3_5_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
         if V_3_IDENTIFIER in model_name:
             return f"tabpfn-{V_3_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
         if V_2_6_IDENTIFIER in model_name:
@@ -142,6 +148,8 @@ class TabPFNModelSelection:
             options["model_path"] = DEFAULT_V2_6_MODEL_PATH
         elif version == ModelVersion.V3:
             options["model_path"] = DEFAULT_V3_MODEL_PATH
+        elif version == ModelVersion.V3_5:
+            options["model_path"] = DEFAULT_V3_5_MODEL_PATH
         else:
             # In case we get UnknownEnum
             raise ValueError(f"Unknown version: {version}")
@@ -153,6 +161,7 @@ class TabPFNModelSelection:
 
 class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
+        DEFAULT_V3_5_MODEL_PATH,
         DEFAULT_V3_MODEL_PATH,
         DEFAULT_V2_6_MODEL_PATH,
         "v2.5_default-2",
@@ -530,6 +539,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
 
 class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
+        DEFAULT_V3_5_MODEL_PATH,
         DEFAULT_V3_MODEL_PATH,
         DEFAULT_V2_6_MODEL_PATH,
         DEFAULT_V2_5_MODEL_PATH,

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -55,18 +55,6 @@ TORCH_AVAILABLE = Tensor is not None
 
 logger = logging.getLogger(__name__)
 
-# Special strings used to identify model families in model paths.
-V_2_5_IDENTIFIER = "v2.5"
-V_2_6_IDENTIFIER = "v2.6"
-V_3_IDENTIFIER = "v3"
-V_3_5_IDENTIFIER = "v3.5"
-
-DEFAULT_V2_MODEL_PATH = "v2_default"
-DEFAULT_V2_5_MODEL_PATH = "v2.5_default"
-DEFAULT_V2_6_MODEL_PATH = "v2.6_default"
-DEFAULT_V3_MODEL_PATH = "v3_default"
-DEFAULT_V3_5_MODEL_PATH = "v3.5_default"
-
 # Sentinel values for `model_path` that defer model selection to the server.
 # `None` means the caller didn't pick a model; "auto" is the canonical name
 # (matches the OSS tabpfn package); "default" is a backward-compatible alias.
@@ -84,7 +72,6 @@ class TabPFNModelSelection:
     """Base class for TabPFN model selection and path handling."""
 
     _AVAILABLE_MODELS: list[str] = []
-    _VALID_TASKS = {"classification", "regression"}
 
     @classmethod
     def list_available_models(cls) -> list[str]:
@@ -104,58 +91,13 @@ class TabPFNModelSelection:
             )
 
     @classmethod
-    def _model_name_to_path(
-        cls, task: Literal["classification", "regression"], model_name: str | None
-    ) -> str | None:
-        cls._validate_model_name(model_name)
-        model_name_task = "classifier" if task == "classification" else "regressor"
-        # Let the server pick the default model when the caller defers to us.
-        if model_name in _AUTO_MODEL_PATH_ALIASES:
-            return None
-        # `None` is one of the auto aliases handled above, so the remainder is a
-        # concrete model name; assert it to narrow `str | None` -> `str`.
-        assert model_name is not None
-        # "v3" is a prefix of "v3.5", so the longer identifier has to be
-        # matched first or every v3.5 name would be filed under v3.
-        if V_3_5_IDENTIFIER in model_name:
-            return f"tabpfn-{V_3_5_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
-        if V_3_IDENTIFIER in model_name:
-            return f"tabpfn-{V_3_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
-        if V_2_6_IDENTIFIER in model_name:
-            return f"tabpfn-{V_2_6_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
-        if V_2_5_IDENTIFIER in model_name:
-            return f"tabpfn-{V_2_5_IDENTIFIER}-{model_name_task}-{model_name}.ckpt"
-        return f"tabpfn-v2-{model_name_task}-{model_name}.ckpt"
-
-    @classmethod
     def create_default_for_version(cls, version: ModelVersion, **overrides) -> Self:
         """Construct an estimator that uses the given version of the model.
 
-        In addition to selecting the model, this also configures the estimator with
-        certain default settings associated with this model version.
-
-        Any kwargs will override the default settings.
+        Any kwargs will override the default settings, except for `model_path`.
         """
-        options: dict[str, Any] = {
-            "n_estimators": 8,
-            "softmax_temperature": 0.9,
-        }
-        if version == ModelVersion.V2:
-            options["model_path"] = DEFAULT_V2_MODEL_PATH
-        elif version == ModelVersion.V2_5:
-            options["model_path"] = DEFAULT_V2_5_MODEL_PATH
-        elif version == ModelVersion.V2_6:
-            options["model_path"] = DEFAULT_V2_6_MODEL_PATH
-        elif version == ModelVersion.V3:
-            options["model_path"] = DEFAULT_V3_MODEL_PATH
-        elif version == ModelVersion.V3_5:
-            options["model_path"] = DEFAULT_V3_5_MODEL_PATH
-        else:
-            # In case we get UnknownEnum
-            raise ValueError(f"Unknown version: {version}")
-
-        options.update(overrides)
-
+        options = overrides.copy()
+        options["model_path"] = f"{version.value}_default"
         return cls(**options)
 
 
@@ -496,7 +438,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in ClassifierTabPFNConfig.model_fields and v is not None
         }
-        cfg["model_path"] = self._model_name_to_path("classification", self.model_path)
         return ClassifierTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> ClassifierPredictParams:
@@ -900,7 +841,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in RegressorTabPFNConfig.model_fields and v is not None
         }
-        cfg["model_path"] = self._model_name_to_path("regression", self.model_path)
         return RegressorTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> RegressorPredictParams:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -435,6 +435,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in ClassifierTabPFNConfig.model_fields and v is not None
         }
+        # "auto"/"default" mean "let the server pick". The API expresses that as
+        # an absent model_path, so keep the alias string off the wire.
+        if cfg.get("model_path") in _AUTO_MODEL_PATH_ALIASES:
+            cfg.pop("model_path", None)
         return ClassifierTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> ClassifierPredictParams:
@@ -834,6 +838,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in RegressorTabPFNConfig.model_fields and v is not None
         }
+        # "auto"/"default" mean "let the server pick". The API expresses that as
+        # an absent model_path, so keep the alias string off the wire.
+        if cfg.get("model_path") in _AUTO_MODEL_PATH_ALIASES:
+            cfg.pop("model_path", None)
         return RegressorTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> RegressorPredictParams:

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 # Sentinel values for `model_path` that defer model selection to the server.
 # `None` means the caller didn't pick a model; "auto" is the canonical name
 # (matches the OSS tabpfn package); "default" is a backward-compatible alias.
-_AUTO_MODEL_PATH_ALIASES: frozenset[str | None] = frozenset({None, "auto", "default"})
+_AUTO_MODEL_PATH_ALIASES = (None, "auto", "default")
 
 # One `<version>_default` alias per model version the API schema declares,
 # newest first (the order users see in `list_available_models()`). The server
@@ -435,10 +435,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in ClassifierTabPFNConfig.model_fields and v is not None
         }
-        # "auto"/"default" mean "let the server pick". The API expresses that as
-        # an absent model_path, so keep the alias string off the wire.
-        if cfg.get("model_path") in _AUTO_MODEL_PATH_ALIASES:
-            cfg.pop("model_path", None)
         return ClassifierTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> ClassifierPredictParams:
@@ -838,10 +834,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
             # Nones are treated as unset
             if k in RegressorTabPFNConfig.model_fields and v is not None
         }
-        # "auto"/"default" mean "let the server pick". The API expresses that as
-        # an absent model_path, so keep the alias string off the wire.
-        if cfg.get("model_path") in _AUTO_MODEL_PATH_ALIASES:
-            cfg.pop("model_path", None)
         return RegressorTabPFNConfig.model_validate(cfg)
 
     def _get_predict_params(self, kwargs: dict[str, Any]) -> RegressorPredictParams:
@@ -897,7 +889,7 @@ def _limit_for_model_path(model_path: str | None) -> ModelLimit | None:
     api_settings = ServiceClient.get_settings()
     if api_settings is None:
         return None
-    if not model_path:
+    if model_path in _AUTO_MODEL_PATH_ALIASES:
         return api_settings.model_limits[api_settings.default_model_version]
     model_version = model_version_from_path(model_path)
     return model_limit_from_version(model_version, api_settings.model_limits)

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -63,7 +63,7 @@ _AUTO_MODEL_PATH_ALIASES = (None, "auto", "default")
 # One `<version>_default` alias per model version the API schema declares,
 # newest first (the order users see in `list_available_models()`). The server
 # resolves each alias to its current default checkpoint for that version.
-_DEFAULT_MODEL_NAMES: list[str] = [f"{v.value}_default" for v in reversed(ModelVersion)]
+_DEFAULT_MODEL_NAMES = tuple(f"{v.value}_default" for v in reversed(ModelVersion))
 
 # Prediction compute scales with n_train_rows * n_test_rows, so the API caps
 # their product. The effective per-call test row limit therefore shrinks as

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -83,7 +83,7 @@ class TabPFNModelSelection:
         return cls._AVAILABLE_MODELS
 
     @classmethod
-    def create_default_for_version(cls, version: ModelVersion, **overrides) -> Self:
+    def create_default_for_version(cls, version: ModelVersion | str, **overrides) -> Self:
         """Construct an estimator that uses the given version of the model.
 
         Any kwargs will override the default settings, except for `model_path`.

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -60,6 +60,11 @@ logger = logging.getLogger(__name__)
 # (matches the OSS tabpfn package); "default" is a backward-compatible alias.
 _AUTO_MODEL_PATH_ALIASES: frozenset[str | None] = frozenset({None, "auto", "default"})
 
+# One `<version>_default` alias per model version the API schema declares,
+# newest first (the order users see in `list_available_models()`). The server
+# resolves each alias to its current default checkpoint for that version.
+_DEFAULT_MODEL_NAMES: list[str] = [f"{v.value}_default" for v in reversed(ModelVersion)]
+
 # Prediction compute scales with n_train_rows * n_test_rows, so the API caps
 # their product. The effective per-call test row limit therefore shrinks as
 # the fitted training set grows (e.g. 1M training rows -> 250k test rows).
@@ -78,24 +83,18 @@ class TabPFNModelSelection:
         return cls._AVAILABLE_MODELS
 
     @classmethod
-    def _validate_model_name(cls, model_name: str | None) -> None:
-        # `None` (defer to the server) is one of the auto aliases, so it counts
-        # as valid rather than an unknown model name.
-        if (
-            model_name not in _AUTO_MODEL_PATH_ALIASES
-            and model_name not in cls._AVAILABLE_MODELS
-        ):
-            raise ValueError(
-                f"Invalid model name: {model_name}. "
-                f"Available models are: {cls.list_available_models()}"
-            )
-
-    @classmethod
     def create_default_for_version(cls, version: ModelVersion, **overrides) -> Self:
         """Construct an estimator that uses the given version of the model.
 
         Any kwargs will override the default settings, except for `model_path`.
         """
+        try:
+            ModelVersion(version)
+        except ValueError:
+            raise ValueError(
+                f"Invalid model version: {version}. "
+                f"Available versions are: {', '.join(list(ModelVersion))}."
+            )
         options = overrides.copy()
         options["model_path"] = f"{version.value}_default"
         return cls(**options)
@@ -103,11 +102,10 @@ class TabPFNModelSelection:
 
 class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
-        DEFAULT_V3_5_MODEL_PATH,
-        DEFAULT_V3_MODEL_PATH,
-        DEFAULT_V2_6_MODEL_PATH,
+        # Downstream packages (e.g. tabpfn-time-series) read this list in order
+        # to parse model names by substring, so must precede "v2.5_default" (its substring).
         "v2.5_default-2",
-        DEFAULT_V2_5_MODEL_PATH,
+        *_DEFAULT_MODEL_NAMES,
         "v2.5_large-features-L",
         "v2.5_large-features-XL",
         "v2.5_large-samples",
@@ -115,7 +113,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
         "v2.5_real-large-samples-and-features",
         "v2.5_real",
         "v2.5_variant",
-        DEFAULT_V2_MODEL_PATH,
         "auto",
         # Deprecated alias for "auto"; kept for backward compat with users and
         # downstream packages (e.g. tabpfn-time-series) that read this list.
@@ -480,17 +477,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator, TabPFNModelSelection):
 
 class TabPFNRegressor(RegressorMixin, BaseEstimator, TabPFNModelSelection):
     _AVAILABLE_MODELS = [
-        DEFAULT_V3_5_MODEL_PATH,
-        DEFAULT_V3_MODEL_PATH,
-        DEFAULT_V2_6_MODEL_PATH,
-        DEFAULT_V2_5_MODEL_PATH,
+        *_DEFAULT_MODEL_NAMES,
         "v2.5_low-skew",
         "v2.5_quantiles",
         "v2.5_real-variant",
         "v2.5_real",
         "v2.5_small-samples",
         "v2.5_variant",
-        DEFAULT_V2_MODEL_PATH,
         "auto",
         # Deprecated alias for "auto"; kept for backward compat with users and
         # downstream packages (e.g. tabpfn-time-series) that read this list.

--- a/src/tabpfn_client/utils.py
+++ b/src/tabpfn_client/utils.py
@@ -21,7 +21,19 @@ def model_limit_from_version(
 
 
 def model_version_from_path(model_path: str) -> ModelVersion:
+    """Best-effort model version of a `model_path` as the caller passed it.
+
+    Accepts checkpoint filenames (`tabpfn-v3-classifier-v3_default.ckpt`) and
+    short names (`v3_default`, `v2.5_real`). Names without a version marker are
+    the v2 hash names (e.g. `gn2p4bpt`), so they resolve to v2. The server is
+    the authority on what a name means; this only picks the limits used for
+    client-side pre-flight checks.
+    """
     for version in ModelVersion:
-        if f"-{version.value}-" in model_path:
+        # "v3" cannot shadow "v3.5" here: both patterns need the separator that
+        # follows the version, and "v3.5" continues with "." instead.
+        if f"-{version.value}-" in model_path or model_path.startswith(
+            f"{version.value}_"
+        ):
             return version
-    raise ValueError(f"Invalid model path: {model_path}")
+    return ModelVersion.V2

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -24,7 +24,7 @@ from tabpfn_client.client import (
     PredictionResult,
     ServiceClient,
 )
-from tabpfn_client.api_models import ClassifierTabPFNConfig
+from tabpfn_client.api_models import ClassifierTabPFNConfig, ModelVersion
 
 
 def _api_settings_payload(
@@ -851,6 +851,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
     def test_list_available_models_returns_expected_models(self):
         expected_models = [
+            "v3.5_default",
             "v3_default",
             "v2.6_default",
             "v2.5_default-2",
@@ -922,9 +923,23 @@ class TestTabPFNModelSelection(unittest.TestCase):
             expected_specific_path,
         )
 
+        # "v3" is a prefix of "v3.5": each has to land in its own family.
+        self.assertEqual(
+            TabPFNClassifier._model_name_to_path("classification", "v3.5_default"),
+            "tabpfn-v3.5-classifier-v3.5_default.ckpt",
+        )
+        self.assertEqual(
+            TabPFNClassifier._model_name_to_path("classification", "v3_default"),
+            "tabpfn-v3-classifier-v3_default.ckpt",
+        )
+
     def test_model_name_to_path_with_invalid_model_raises_error(self):
         with self.assertRaises(ValueError):
             TabPFNClassifier._model_name_to_path("classification", "invalid_model")
+
+    def test_create_default_for_version_v3_5_selects_the_alias(self):
+        estimator = TabPFNClassifier.create_default_for_version(ModelVersion.V3_5)
+        self.assertEqual(estimator.model_path, "v3.5_default")
 
     def test_predict_proba_uses_correct_model_path(self):
         # Setup

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -892,6 +892,19 @@ class TestTabPFNModelSelection(unittest.TestCase):
         estimator = TabPFNClassifier.create_default_for_version(ModelVersion.V3_5)
         self.assertEqual(estimator.model_path, "v3.5_default")
 
+    def test_auto_aliases_send_no_model_path(self):
+        # `None`, "auto" and "default" all mean "let the server pick". The API
+        # expresses that as an absent model_path, so none of them may reach the
+        # wire as a string: the server rejects unknown names, and the client's
+        # limit checks would file them under v2.
+        for alias in (None, "auto", "default"):
+            with self.subTest(model_path=alias):
+                cfg = TabPFNClassifier(model_path=alias)._get_tabpfn_config()
+                self.assertIsNone(cfg.model_path)
+        # Concrete names pass through unchanged for the server to resolve.
+        cfg = TabPFNClassifier(model_path="v3.5_default")._get_tabpfn_config()
+        self.assertEqual(cfg.model_path, "v3.5_default")
+
     def test_predict_proba_uses_correct_model_path(self):
         # Setup
         X = np.random.rand(10, 5)

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -851,11 +851,12 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
     def test_list_available_models_returns_expected_models(self):
         expected_models = [
+            "v2.5_default-2",
             "v3.5_default",
             "v3_default",
             "v2.6_default",
-            "v2.5_default-2",
             "v2.5_default",
+            "v2_default",
             "v2.5_large-features-L",
             "v2.5_large-features-XL",
             "v2.5_large-samples",
@@ -863,7 +864,6 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v2.5_real-large-samples-and-features",
             "v2.5_real",
             "v2.5_variant",
-            "v2_default",
             "auto",
             "default",
             "gn2p4bpt",
@@ -887,55 +887,6 @@ class TestTabPFNModelSelection(unittest.TestCase):
             for j in range(i + 1, len(model_names)):
                 model_name = model_names[j]
                 self.assertNotIn(possible_substring, model_name)
-
-    def test_validate_model_name_with_valid_model_passes(self):
-        # Should not raise any exception
-        TabPFNClassifier._validate_model_name("auto")
-        # "default" remains accepted as a backward-compatible alias for "auto".
-        TabPFNClassifier._validate_model_name("default")
-        TabPFNClassifier._validate_model_name("gn2p4bpt")
-
-    def test_validate_model_name_with_invalid_model_raises_error(self):
-        with self.assertRaises(ValueError):
-            TabPFNClassifier._validate_model_name("invalid_model")
-
-    def test_model_name_to_path_returns_expected_path(self):
-        # Test auto model path. Server decides.
-        self.assertIsNone(
-            TabPFNClassifier._model_name_to_path("classification", "auto"),
-        )
-        # "default" alias resolves the same way.
-        self.assertIsNone(
-            TabPFNClassifier._model_name_to_path("classification", "default"),
-        )
-
-        # Test specific model path
-        expected_specific_path = "tabpfn-v2-classifier-gn2p4bpt.ckpt"
-        self.assertEqual(
-            TabPFNClassifier._model_name_to_path("classification", "gn2p4bpt"),
-            expected_specific_path,
-        )
-
-        # Test specific v2.5 model path
-        expected_specific_path = "tabpfn-v2.5-classifier-v2.5_default.ckpt"
-        self.assertEqual(
-            TabPFNClassifier._model_name_to_path("classification", "v2.5_default"),
-            expected_specific_path,
-        )
-
-        # "v3" is a prefix of "v3.5": each has to land in its own family.
-        self.assertEqual(
-            TabPFNClassifier._model_name_to_path("classification", "v3.5_default"),
-            "tabpfn-v3.5-classifier-v3.5_default.ckpt",
-        )
-        self.assertEqual(
-            TabPFNClassifier._model_name_to_path("classification", "v3_default"),
-            "tabpfn-v3-classifier-v3_default.ckpt",
-        )
-
-    def test_model_name_to_path_with_invalid_model_raises_error(self):
-        with self.assertRaises(ValueError):
-            TabPFNClassifier._model_name_to_path("classification", "invalid_model")
 
     def test_create_default_for_version_v3_5_selects_the_alias(self):
         estimator = TabPFNClassifier.create_default_for_version(ModelVersion.V3_5)
@@ -961,9 +912,9 @@ class TestTabPFNModelSelection(unittest.TestCase):
                 tabpfn.fit(X, y)
                 tabpfn.predict_proba(X)
 
-                # Verify the model path was correctly passed to predict
+                # The name is passed through unchanged; the server resolves it.
                 predict_kwargs = mock_predict.call_args[1]
-                expected_model_path = "tabpfn-v2-classifier-gn2p4bpt.ckpt"
+                expected_model_path = "gn2p4bpt"
 
                 self.assertEqual(
                     predict_kwargs["task_config"].tabpfn_config.model_path,

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -14,7 +14,7 @@ from sklearn.exceptions import NotFittedError
 
 
 from tabpfn_client import init, reset
-from tabpfn_client.estimator import TabPFNClassifier, _limit_for_model_path
+from tabpfn_client.estimator import TabPFNClassifier
 from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
@@ -906,27 +906,6 @@ class TestTabPFNModelSelection(unittest.TestCase):
         # Concrete names pass through unchanged as well.
         cfg = TabPFNClassifier(model_path="v3.5_default")._get_tabpfn_config()
         self.assertEqual(cfg.model_path, "v3.5_default")
-
-    def test_auto_aliases_use_the_default_version_limits(self):
-        # The aliases carry no version, so the pre-flight checks must use the
-        # server's default version rather than the v2 fallback for bare names.
-        payload = _api_settings_payload()
-        v2_limit = {**payload["max_model_limit"], "test_set_max_rows": 10}
-        v3_limit = {**payload["max_model_limit"], "test_set_max_rows": 1000}
-        payload["default_model_version"] = "v3"
-        payload["model_limits"] = {"v2": v2_limit, "v3": v3_limit}
-        settings = GetSettingsResponse(**payload)
-        with (
-            patch.object(ServiceClient, "_api_settings", settings),
-            patch.object(ServiceClient, "_api_settings_ts", time.monotonic()),
-        ):
-            for alias in (None, "auto", "default"):
-                with self.subTest(model_path=alias):
-                    limit = _limit_for_model_path(alias)
-                    self.assertEqual(limit.test_set_max_rows, 1000)
-            # Versioned and bare (v2 hash) names still resolve to their own version.
-            self.assertEqual(_limit_for_model_path("v2_default").test_set_max_rows, 10)
-            self.assertEqual(_limit_for_model_path("gn2p4bpt").test_set_max_rows, 10)
 
     def test_predict_proba_uses_correct_model_path(self):
         # Setup

--- a/tests/unit/test_tabpfn_classifier.py
+++ b/tests/unit/test_tabpfn_classifier.py
@@ -14,7 +14,7 @@ from sklearn.exceptions import NotFittedError
 
 
 from tabpfn_client import init, reset
-from tabpfn_client.estimator import TabPFNClassifier
+from tabpfn_client.estimator import TabPFNClassifier, _limit_for_model_path
 from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
@@ -892,18 +892,41 @@ class TestTabPFNModelSelection(unittest.TestCase):
         estimator = TabPFNClassifier.create_default_for_version(ModelVersion.V3_5)
         self.assertEqual(estimator.model_path, "v3.5_default")
 
-    def test_auto_aliases_send_no_model_path(self):
-        # `None`, "auto" and "default" all mean "let the server pick". The API
-        # expresses that as an absent model_path, so none of them may reach the
-        # wire as a string: the server rejects unknown names, and the client's
-        # limit checks would file them under v2.
-        for alias in (None, "auto", "default"):
+    def test_auto_aliases_pass_through_on_the_wire(self):
+        # `None`, "auto" and "default" all mean "let the server pick". The server
+        # owns alias resolution, so the strings go out as given; only `None` is
+        # an absent field.
+        self.assertIsNone(
+            TabPFNClassifier(model_path=None)._get_tabpfn_config().model_path
+        )
+        for alias in ("auto", "default"):
             with self.subTest(model_path=alias):
                 cfg = TabPFNClassifier(model_path=alias)._get_tabpfn_config()
-                self.assertIsNone(cfg.model_path)
-        # Concrete names pass through unchanged for the server to resolve.
+                self.assertEqual(cfg.model_path, alias)
+        # Concrete names pass through unchanged as well.
         cfg = TabPFNClassifier(model_path="v3.5_default")._get_tabpfn_config()
         self.assertEqual(cfg.model_path, "v3.5_default")
+
+    def test_auto_aliases_use_the_default_version_limits(self):
+        # The aliases carry no version, so the pre-flight checks must use the
+        # server's default version rather than the v2 fallback for bare names.
+        payload = _api_settings_payload()
+        v2_limit = {**payload["max_model_limit"], "test_set_max_rows": 10}
+        v3_limit = {**payload["max_model_limit"], "test_set_max_rows": 1000}
+        payload["default_model_version"] = "v3"
+        payload["model_limits"] = {"v2": v2_limit, "v3": v3_limit}
+        settings = GetSettingsResponse(**payload)
+        with (
+            patch.object(ServiceClient, "_api_settings", settings),
+            patch.object(ServiceClient, "_api_settings_ts", time.monotonic()),
+        ):
+            for alias in (None, "auto", "default"):
+                with self.subTest(model_path=alias):
+                    limit = _limit_for_model_path(alias)
+                    self.assertEqual(limit.test_set_max_rows, 1000)
+            # Versioned and bare (v2 hash) names still resolve to their own version.
+            self.assertEqual(_limit_for_model_path("v2_default").test_set_max_rows, 10)
+            self.assertEqual(_limit_for_model_path("gn2p4bpt").test_set_max_rows, 10)
 
     def test_predict_proba_uses_correct_model_path(self):
         # Setup

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -25,7 +25,7 @@ from tabpfn_client.client import (
     PredictionResult,
     ServiceClient,
 )
-from tabpfn_client.api_models import RegressorTabPFNConfig
+from tabpfn_client.api_models import ModelVersion, RegressorTabPFNConfig
 
 
 def _api_settings_payload(
@@ -857,6 +857,7 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
     def test_list_available_models_returns_expected_models(self):
         expected_models = [
+            "v3.5_default",
             "v3_default",
             "v2.6_default",
             "v2.5_default",
@@ -925,9 +926,23 @@ class TestTabPFNModelSelection(unittest.TestCase):
             expected_specific_path,
         )
 
+        # "v3" is a prefix of "v3.5": each has to land in its own family.
+        self.assertEqual(
+            TabPFNRegressor._model_name_to_path("regression", "v3.5_default"),
+            "tabpfn-v3.5-regressor-v3.5_default.ckpt",
+        )
+        self.assertEqual(
+            TabPFNRegressor._model_name_to_path("regression", "v3_default"),
+            "tabpfn-v3-regressor-v3_default.ckpt",
+        )
+
     def test_model_name_to_path_with_invalid_model_raises_error(self):
         with self.assertRaises(ValueError):
             TabPFNRegressor._model_name_to_path("regression", "invalid_model")
+
+    def test_create_default_for_version_v3_5_selects_the_alias(self):
+        estimator = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5)
+        self.assertEqual(estimator.model_path, "v3.5_default")
 
     def test_predict_uses_correct_model_path(self):
         # Setup

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -895,6 +895,19 @@ class TestTabPFNModelSelection(unittest.TestCase):
         estimator = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5)
         self.assertEqual(estimator.model_path, "v3.5_default")
 
+    def test_auto_aliases_send_no_model_path(self):
+        # `None`, "auto" and "default" all mean "let the server pick". The API
+        # expresses that as an absent model_path, so none of them may reach the
+        # wire as a string: the server rejects unknown names, and the client's
+        # limit checks would file them under v2.
+        for alias in (None, "auto", "default"):
+            with self.subTest(model_path=alias):
+                cfg = TabPFNRegressor(model_path=alias)._get_tabpfn_config()
+                self.assertIsNone(cfg.model_path)
+        # Concrete names pass through unchanged for the server to resolve.
+        cfg = TabPFNRegressor(model_path="v3.5_default")._get_tabpfn_config()
+        self.assertEqual(cfg.model_path, "v3.5_default")
+
     def test_predict_uses_correct_model_path(self):
         # Setup
         X = np.random.rand(10, 5)

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -14,7 +14,7 @@ from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.exceptions import NotFittedError
 
 from tabpfn_client import init, reset
-from tabpfn_client.estimator import TabPFNRegressor
+from tabpfn_client.estimator import TabPFNRegressor, _limit_for_model_path
 from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
@@ -895,18 +895,41 @@ class TestTabPFNModelSelection(unittest.TestCase):
         estimator = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5)
         self.assertEqual(estimator.model_path, "v3.5_default")
 
-    def test_auto_aliases_send_no_model_path(self):
-        # `None`, "auto" and "default" all mean "let the server pick". The API
-        # expresses that as an absent model_path, so none of them may reach the
-        # wire as a string: the server rejects unknown names, and the client's
-        # limit checks would file them under v2.
-        for alias in (None, "auto", "default"):
+    def test_auto_aliases_pass_through_on_the_wire(self):
+        # `None`, "auto" and "default" all mean "let the server pick". The server
+        # owns alias resolution, so the strings go out as given; only `None` is
+        # an absent field.
+        self.assertIsNone(
+            TabPFNRegressor(model_path=None)._get_tabpfn_config().model_path
+        )
+        for alias in ("auto", "default"):
             with self.subTest(model_path=alias):
                 cfg = TabPFNRegressor(model_path=alias)._get_tabpfn_config()
-                self.assertIsNone(cfg.model_path)
-        # Concrete names pass through unchanged for the server to resolve.
+                self.assertEqual(cfg.model_path, alias)
+        # Concrete names pass through unchanged as well.
         cfg = TabPFNRegressor(model_path="v3.5_default")._get_tabpfn_config()
         self.assertEqual(cfg.model_path, "v3.5_default")
+
+    def test_auto_aliases_use_the_default_version_limits(self):
+        # The aliases carry no version, so the pre-flight checks must use the
+        # server's default version rather than the v2 fallback for bare names.
+        payload = _api_settings_payload()
+        v2_limit = {**payload["max_model_limit"], "test_set_max_rows": 10}
+        v3_limit = {**payload["max_model_limit"], "test_set_max_rows": 1000}
+        payload["default_model_version"] = "v3"
+        payload["model_limits"] = {"v2": v2_limit, "v3": v3_limit}
+        settings = GetSettingsResponse(**payload)
+        with (
+            patch.object(ServiceClient, "_api_settings", settings),
+            patch.object(ServiceClient, "_api_settings_ts", time.monotonic()),
+        ):
+            for alias in (None, "auto", "default"):
+                with self.subTest(model_path=alias):
+                    limit = _limit_for_model_path(alias)
+                    self.assertEqual(limit.test_set_max_rows, 1000)
+            # Versioned and bare (v2 hash) names still resolve to their own version.
+            self.assertEqual(_limit_for_model_path("v2_default").test_set_max_rows, 10)
+            self.assertEqual(_limit_for_model_path("2noar4o2").test_set_max_rows, 10)
 
     def test_predict_uses_correct_model_path(self):
         # Setup

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -861,13 +861,13 @@ class TestTabPFNModelSelection(unittest.TestCase):
             "v3_default",
             "v2.6_default",
             "v2.5_default",
+            "v2_default",
             "v2.5_low-skew",
             "v2.5_quantiles",
             "v2.5_real-variant",
             "v2.5_real",
             "v2.5_small-samples",
             "v2.5_variant",
-            "v2_default",
             "auto",
             "default",
             "2noar4o2",
@@ -890,55 +890,6 @@ class TestTabPFNModelSelection(unittest.TestCase):
             for j in range(i + 1, len(model_names)):
                 model_name = model_names[j]
                 self.assertNotIn(possible_substring, model_name)
-
-    def test_validate_model_name_with_valid_model_passes(self):
-        # Should not raise any exception
-        TabPFNRegressor._validate_model_name("auto")
-        # "default" remains accepted as a backward-compatible alias for "auto".
-        TabPFNRegressor._validate_model_name("default")
-        TabPFNRegressor._validate_model_name("2noar4o2")
-
-    def test_validate_model_name_with_invalid_model_raises_error(self):
-        with self.assertRaises(ValueError):
-            TabPFNRegressor._validate_model_name("invalid_model")
-
-    def test_model_name_to_path_returns_expected_path(self):
-        # Test auto model path. Server decides.
-        self.assertIsNone(
-            TabPFNRegressor._model_name_to_path("regression", "auto"),
-        )
-        # "default" alias resolves the same way.
-        self.assertIsNone(
-            TabPFNRegressor._model_name_to_path("regression", "default"),
-        )
-
-        # Test specific model path
-        expected_specific_path = "tabpfn-v2-regressor-2noar4o2.ckpt"
-        self.assertEqual(
-            TabPFNRegressor._model_name_to_path("regression", "2noar4o2"),
-            expected_specific_path,
-        )
-
-        # Test specific v2.5 model path
-        expected_specific_path = "tabpfn-v2.5-regressor-v2.5_default.ckpt"
-        self.assertEqual(
-            TabPFNRegressor._model_name_to_path("regression", "v2.5_default"),
-            expected_specific_path,
-        )
-
-        # "v3" is a prefix of "v3.5": each has to land in its own family.
-        self.assertEqual(
-            TabPFNRegressor._model_name_to_path("regression", "v3.5_default"),
-            "tabpfn-v3.5-regressor-v3.5_default.ckpt",
-        )
-        self.assertEqual(
-            TabPFNRegressor._model_name_to_path("regression", "v3_default"),
-            "tabpfn-v3-regressor-v3_default.ckpt",
-        )
-
-    def test_model_name_to_path_with_invalid_model_raises_error(self):
-        with self.assertRaises(ValueError):
-            TabPFNRegressor._model_name_to_path("regression", "invalid_model")
 
     def test_create_default_for_version_v3_5_selects_the_alias(self):
         estimator = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5)
@@ -963,9 +914,9 @@ class TestTabPFNModelSelection(unittest.TestCase):
                 tabpfn.fit(X, y)
                 tabpfn.predict(X)
 
-                # Verify the model path was correctly passed to predict
+                # The name is passed through unchanged; the server resolves it.
                 predict_kwargs = mock_predict.call_args[1]
-                expected_model_path = "tabpfn-v2-regressor-2noar4o2.ckpt"
+                expected_model_path = "2noar4o2"
 
                 self.assertEqual(
                     predict_kwargs["task_config"].tabpfn_config.model_path,

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -14,7 +14,7 @@ from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.exceptions import NotFittedError
 
 from tabpfn_client import init, reset
-from tabpfn_client.estimator import TabPFNRegressor, _limit_for_model_path
+from tabpfn_client.estimator import TabPFNRegressor
 from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
@@ -909,27 +909,6 @@ class TestTabPFNModelSelection(unittest.TestCase):
         # Concrete names pass through unchanged as well.
         cfg = TabPFNRegressor(model_path="v3.5_default")._get_tabpfn_config()
         self.assertEqual(cfg.model_path, "v3.5_default")
-
-    def test_auto_aliases_use_the_default_version_limits(self):
-        # The aliases carry no version, so the pre-flight checks must use the
-        # server's default version rather than the v2 fallback for bare names.
-        payload = _api_settings_payload()
-        v2_limit = {**payload["max_model_limit"], "test_set_max_rows": 10}
-        v3_limit = {**payload["max_model_limit"], "test_set_max_rows": 1000}
-        payload["default_model_version"] = "v3"
-        payload["model_limits"] = {"v2": v2_limit, "v3": v3_limit}
-        settings = GetSettingsResponse(**payload)
-        with (
-            patch.object(ServiceClient, "_api_settings", settings),
-            patch.object(ServiceClient, "_api_settings_ts", time.monotonic()),
-        ):
-            for alias in (None, "auto", "default"):
-                with self.subTest(model_path=alias):
-                    limit = _limit_for_model_path(alias)
-                    self.assertEqual(limit.test_set_max_rows, 1000)
-            # Versioned and bare (v2 hash) names still resolve to their own version.
-            self.assertEqual(_limit_for_model_path("v2_default").test_set_max_rows, 10)
-            self.assertEqual(_limit_for_model_path("2noar4o2").test_set_max_rows, 10)
 
     def test_predict_uses_correct_model_path(self):
         # Setup

--- a/uv.lock
+++ b/uv.lock
@@ -1427,7 +1427,7 @@ wheels = [
 
 [[package]]
 name = "tabpfn-client"
-version = "0.4.2"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },
@@ -1472,14 +1472,14 @@ requires-dist = [
     { name = "omegaconf", specifier = ">=2.1.2,<=2.3.0" },
     { name = "pandas", specifier = ">=2.1.2,<=2.3.3" },
     { name = "password-strength", specifier = ">=0.0.3.post2,<=0.0.3.post2" },
-    { name = "pyarrow", specifier = ">=14.0.0,<=23.0.1" },
+    { name = "pyarrow", specifier = ">=14.0.0,<=25.0.1" },
     { name = "pydantic", specifier = ">=2.11.7,<=2.13.4" },
-    { name = "pydantic-settings", specifier = ">=2.14.2,<=2.14.2" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<=2.15.0" },
     { name = "rich", specifier = ">=13.7.0,<=15.0.0" },
     { name = "scikit-learn", specifier = ">=1.3.1,<=1.9.0" },
     { name = "sseclient-py", specifier = ">=1.8.0,<=1.9.0" },
     { name = "tabpfn-common-utils", specifier = ">=0.2.10,<=0.2.19" },
-    { name = "tqdm", specifier = ">=4.63.0,<=4.67.3" },
+    { name = "tqdm", specifier = ">=4.63.0,<=4.70.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<=4.16.0" },
     { name = "xxhash", specifier = ">=1.1.0,<=3.8.1" },
 ]


### PR DESCRIPTION
[ENG-975](https://linear.app/priorlabs/issue/ENG-975/update-client-for-tabpfn-35-checkpoint-naming)

### Change Description

Adds the `v3.5_default` alias and stops resolving model names on the client: `model_path` now goes to the server unchanged, and the server owns the name → checkpoint mapping.

- `model_path` is sent as given (`v3.5_default`, `v2.5_real`, `gn2p4bpt`, or a full checkpoint filename). `_model_name_to_path`, the family identifier constants and client-side name validation are removed. `None` sends no `model_path`; `"auto"` / `"default"` go through as given and the server resolves them. The client keeps the alias list only to pick the default-version limits for its pre-flight checks.
- The `<version>_default` entries of `list_available_models()` are derived from `ModelVersion` (newest first) instead of hand-maintained constants; `ModelVersion.V3_5` is added. `create_default_for_version` builds the alias the same way and rejects versions not in the enum. The substring-safe ordering that tabpfn-time-series relies on is kept and tested.
- `model_version_from_path` accepts short names as well as filenames, so the client-side pre-flight limit checks and full-output chunking keep working; bare hash names resolve to v2.

Tests cover the pinned model lists, pass-through of the name on the wire and `create_default_for_version(ModelVersion.V3_5)`; tests for the removed helpers are dropped.

Motivation: the tabpfn-server v3.5 smoke test (`basic_v3_5` preset) uses this alias; the pinned client rejects it today.

**If you used new dependencies: Did you add them to `requirements.txt`?** No new dependencies.

**Who did you ping on Mattermost to review your PR?** —

## Breaking changes

**Does this PR break the API? If so, what is the corresponding server commit?** Wire change: the client sends short model names instead of `tabpfn-<family>-<task>-<name>.ckpt` filenames. gapi's `fill_or_validate_model_path` must accept and resolve them (not yet on tabpfn-server `main`). Until it does, any explicit `model_path`, including `"auto"` / `"default"`, fails at fit with the server's invalid-model-path error; only `None` and full checkpoint filenames keep working.

**Does this PR break the user interface? If so, why?** Two small behaviour changes: `create_default_for_version` no longer sets `n_estimators=8` / `softmax_temperature=0.9`, it only pins `model_path`; and unknown model names are no longer rejected locally but by the server at fit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

