### PR TITLE
Forward `model_version` to the endpoint

### DIFF
--- a/changelog/379.added.md
+++ b/changelog/379.added.md
@@ -1,0 +1,1 @@
+`tabpfn_client.hosted.TabPFNClassifier` and `TabPFNRegressor` accept `model_version="v3.5"` (or any other baked family) to select a weights family on serving containers that support it. Older containers keep working — the field is only sent when set.

--- a/src/tabpfn_client/hosted/estimator.py
+++ b/src/tabpfn_client/hosted/estimator.py
@@ -25,6 +25,10 @@ place, set `fit_mode="fit_with_cache"`; the endpoint then returns a
 `model_id=prior.model_id_`. `model_path` is similarly optional and
 only sent when set; some deployments reject overrides.
 
+`model_version` selects one of the weights families the endpoint has
+baked (e.g. `"v3"`, `"v3.5"`). Only sent when set, so older containers
+that don't know the field keep working.
+
 `use_kv_cache=True` automates that round trip within one estimator: the
 first `predict*` after `fit()` ships the training data as usual, and
 every later one reuses the `model_id` the endpoint returned. Workloads
@@ -94,6 +98,7 @@ class _HostedBase(BaseEstimator):
         extra_headers: Optional[Dict[str, str]] = None,
         model_id: Optional[str] = None,
         model_path: Optional[str] = None,
+        model_version: Optional[str] = None,
         fit_mode: Optional[
             Literal["fit_preprocessors", "low_memory", "fit_with_cache", "batched"]
         ] = None,
@@ -116,6 +121,7 @@ class _HostedBase(BaseEstimator):
         self.extra_headers = extra_headers
         self.model_id = model_id
         self.model_path = model_path
+        self.model_version = model_version
         self.fit_mode = fit_mode
         self.n_estimators = n_estimators
         self.softmax_temperature = softmax_temperature
@@ -223,6 +229,12 @@ class _HostedBase(BaseEstimator):
                 "predict_params": params,
             }
         }
+        # Sits at the top level of the request, not under tabpfn_config — the
+        # serving container reads it there to resolve a baked checkpoint path.
+        # Omitted when unset so older containers that reject unknown fields
+        # (422) keep working.
+        if self.model_version is not None:
+            request["model_version"] = self.model_version
         datasets: Dict[str, Any] = {"x_test": X_test}
 
         # Precedence: a completed fit() wins over the constructor's model_id.

--- a/tests/unit/test_hosted_estimator.py
+++ b/tests/unit/test_hosted_estimator.py
@@ -252,6 +252,37 @@ class TestKvCache:
         assert "X_train" not in body
 
 
+class TestModelVersion:
+    def test_default_omits_the_field(self):
+        """Compat with older containers: an unknown field would 422."""
+        recorder = Recorder()
+        model = _classifier(recorder)
+        model.fit(X_COMPLETE, Y)
+        model.predict_proba(X_COMPLETE.iloc[:2])
+
+        assert "model_version" not in recorder.json_body()
+
+    def test_explicit_value_sits_at_the_top_level(self):
+        """The serving container reads `req.model_version`, not under `tabpfn_config`."""
+        recorder = Recorder()
+        model = _classifier(recorder, model_version="v3.5")
+        model.fit(X_COMPLETE, Y)
+        model.predict_proba(X_COMPLETE.iloc[:2])
+
+        body = recorder.json_body()
+        assert body["model_version"] == "v3.5"
+        assert "model_version" not in body["task_config"]["tabpfn_config"]
+
+    def test_travels_on_the_parquet_payload_too(self):
+        recorder = Recorder()
+        model = _classifier(recorder, payload_format="parquet", model_version="v3")
+        model.fit(X, Y)
+        model.predict_proba(X.iloc[:2])
+
+        config, _ = recorder.multipart()
+        assert config["model_version"] == "v3"
+
+
 class TestNonFiniteJson:
     def test_missing_and_infinite_values_survive_the_json_path(self):
         """Explainers mask features with +inf; httpx's `json=` would reject it."""


### PR DESCRIPTION
Select a baked weights family (e.g. "v3") when the endpoint supports it. Omitted from the request body when unset, so older containers that reject unknown fields keep working. 