### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-09-04
+
+### Added
+
+- `TabPFNClassifier` and `TabPFNRegressor` accept `model_path="v3.5_default"` (and `create_default_for_version(ModelVersion.V3_5)`) to request the TabPFN 3.5 pre-release on accounts that have access to it. ([#374](https://github.com/PriorLabs/tabpfn-client/pull/374))
+- Add ``plot_regression_distribution`` to visualise the predictive distribution returned by regression predictions with ``output_type="full"``. Install the optional plotting dependencies with ``pip install "tabpfn-client[viz]"``. ([#375](https://github.com/PriorLabs/tabpfn-client/pull/375))
+- `tabpfn_client.hosted.TabPFNClassifier` and `TabPFNRegressor` accept `model_version="v3.5"` (or any other baked family) to select a weights family on serving containers that support it. Older containers keep working — the field is only sent when set. ([#379](https://github.com/PriorLabs/tabpfn-client/pull/379))
+
+
 ## [0.5.1] - 2026-09-01
 
 ### Added

--- a/changelog/374.added.md
+++ b/changelog/374.added.md
@@ -1,1 +1,0 @@
-`TabPFNClassifier` and `TabPFNRegressor` accept `model_path="v3.5_default"` (and `create_default_for_version(ModelVersion.V3_5)`) to request the TabPFN 3.5 pre-release on accounts that have access to it.

--- a/changelog/375.added.md
+++ b/changelog/375.added.md
@@ -1,1 +1,0 @@
-Add ``plot_regression_distribution`` to visualise the predictive distribution returned by regression predictions with ``output_type="full"``. Install the optional plotting dependencies with ``pip install "tabpfn-client[viz]"``.

--- a/changelog/379.added.md
+++ b/changelog/379.added.md
@@ -1,1 +1,0 @@
-`tabpfn_client.hosted.TabPFNClassifier` and `TabPFNRegressor` accept `model_version="v3.5"` (or any other baked family) to select a weights family on serving containers that support it. Older containers keep working — the field is only sent when set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.5.1"
+version = "0.5.2"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Automated release PR for v0.5.2, cut from 61b2f4a76cdf376727cbe65a3739a5ead8fae316.

Merging this tags `v0.5.2` and starts the publish workflow, which
uploads to TestPyPI, installs the result from there to verify it, and
then publishes to PyPI.

The PyPI step runs in the `pypi` environment. Whether it pauses for a
review depends on that environment carrying a required reviewer, which
is repository configuration rather than anything this workflow can
assert -- an environment with no protection rules publishes
unattended.