### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-09-05
+
+### Fixed
+
+- `tabpfn_client.hosted.TabPFNClassifier` and `TabPFNRegressor` no longer force client-side defaults for `n_estimators`, `softmax_temperature`, `average_before_softmax`, and `inference_precision`. Unset values now defer to the inference container's own defaults; user-supplied overrides still win. ([#378](https://github.com/PriorLabs/tabpfn-client/pull/378))
+
+
 ## [0.5.2] - 2026-09-04
 
 ### Added

--- a/changelog/378.fixed.md
+++ b/changelog/378.fixed.md
@@ -1,1 +1,0 @@
-`tabpfn_client.hosted.TabPFNClassifier` and `TabPFNRegressor` no longer force client-side defaults for `n_estimators`, `softmax_temperature`, `average_before_softmax`, and `inference_precision`. Unset values now defer to the inference container's own defaults; user-supplied overrides still win.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.5.2"
+version = "0.5.3"
 requires-python = ">=3.10"
 
 description = "API access for TabPFN: Foundation model for tabular data"


### PR DESCRIPTION
Automated release PR for v0.5.3, cut from b43fccff26255189909c72110c92517113d63264.

Merging this tags `v0.5.3` and starts the publish workflow, which
uploads to TestPyPI, installs the result from there to verify it, and
then publishes to PyPI.

The PyPI step runs in the `pypi` environment. Whether it pauses for a
review depends on that environment carrying a required reviewer, which
is repository configuration rather than anything this workflow can
assert -- an environment with no protection rules publishes
unattended.