### PR TITLE
docs: add concise estimator usage guidance

### DIFF
--- a/changelog/383.changed.md
+++ b/changelog/383.changed.md
@@ -1,0 +1,1 @@
+Clarify estimator usage guidance for TabPFN-3 and later versions, covering dataset capacity, subsampling, and automatic handling of categorical values, raw text, and missing feature values without manual preprocessing.

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -104,6 +104,19 @@ class TabPFNModelSelection:
 
 
 class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelection):
+    """Hosted TabPFN classifier with a scikit-learn-compatible interface.
+
+    Usage guidance:
+        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
+          model/API limits.
+        - For large datasets or limited memory, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
+          strings/categories and missing feature values are handled automatically;
+          no manual integer/one-hot encoding, imputation, scaling, or outlier
+          removal is needed.
+    """
+
     _AVAILABLE_MODELS = [
         # Downstream packages (e.g. tabpfn-time-series) read this list in order
         # to parse model names by substring, so "v2.5_default-2" must precede "v2.5_default".
@@ -464,6 +477,19 @@ class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelect
 
 
 class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelection):
+    """Hosted TabPFN regressor with a scikit-learn-compatible interface.
+
+    Usage guidance:
+        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
+          model/API limits.
+        - For large datasets or limited memory, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
+          strings/categories and missing feature values are handled automatically;
+          no manual integer/one-hot encoding, imputation, scaling, or outlier
+          removal is needed.
+    """
+
     _AVAILABLE_MODELS = [
         *_DEFAULT_MODEL_NAMES,
         "v2.5_low-skew",

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -109,12 +109,12 @@ class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelect
     Usage guidance:
         - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
           model/API limits.
-        - For large datasets or limited memory, use per-estimator subsampling,
-          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - For large datasets, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 100_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
-          strings/categories and missing feature values are handled automatically;
-          no manual integer/one-hot encoding, imputation, scaling, or outlier
-          removal is needed.
+          strings/categories, raw text, and missing feature values are handled
+          automatically; no manual integer/one-hot encoding, imputation, scaling,
+          or outlier removal is needed.
     """
 
     _AVAILABLE_MODELS = [
@@ -482,12 +482,12 @@ class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelectio
     Usage guidance:
         - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
           model/API limits.
-        - For large datasets or limited memory, use per-estimator subsampling,
-          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - For large datasets, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 100_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
-          strings/categories and missing feature values are handled automatically;
-          no manual integer/one-hot encoding, imputation, scaling, or outlier
-          removal is needed.
+          strings/categories, raw text, and missing feature values are handled
+          automatically; no manual integer/one-hot encoding, imputation, scaling,
+          or outlier removal is needed.
     """
 
     _AVAILABLE_MODELS = [

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -107,8 +107,8 @@ class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelect
     """Hosted TabPFN classifier with a scikit-learn-compatible interface.
 
     Usage guidance:
-        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
-          model/API limits.
+        - TabPFN-3 and later versions support up to 1,000,000 rows, subject to
+          feature count and model/API limits.
         - For large datasets, use per-estimator subsampling,
           e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 100_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
@@ -480,8 +480,8 @@ class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelectio
     """Hosted TabPFN regressor with a scikit-learn-compatible interface.
 
     Usage guidance:
-        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count and
-          model/API limits.
+        - TabPFN-3 and later versions support up to 1,000,000 rows, subject to
+          feature count and model/API limits.
         - For large datasets, use per-estimator subsampling,
           e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 100_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical


### PR DESCRIPTION
Agents often impose an outdated 10k-row cap and add unnecessary preprocessing. Add concise classifier/regressor docstrings covering TabPFN-3's capacity of up to 1M rows, per-estimator subsampling with a 100K example, and automatic handling of categorical values, raw text, and missing feature values.

Validation: Ruff formatting/lint and `git diff --check` passed. Documentation only; no API changes.
