### PR TITLE
fix: re-export ModelVersion from tabpfn_client.constants

### DIFF
--- a/changelog/384.fixed.md
+++ b/changelog/384.fixed.md
@@ -1,0 +1,1 @@
+Restore `from tabpfn_client.constants import ModelVersion`, which broke when the enum moved to `tabpfn_client.api_models`.

--- a/src/tabpfn_client/constants.py
+++ b/src/tabpfn_client/constants.py
@@ -3,6 +3,9 @@
 
 from pathlib import Path
 
+# Re-export: `tabpfn_client.constants.ModelVersion` is public API.
+from tabpfn_client.api_models import ModelVersion as ModelVersion
+
 CACHE_DIR = Path(__file__).parent.resolve() / ".tabpfn"
 
 URL_TABPFN_CLIENT_GITHUB_ISSUES = "https://github.com/priorlabs/tabpfn-client/issues"

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,5 @@
+from tabpfn_client import api_models, constants
+
+
+def test_model_version_is_importable_from_constants():
+    assert constants.ModelVersion is api_models.ModelVersion


### PR DESCRIPTION
`ModelVersion` moved from `tabpfn_client.constants` to `tabpfn_client.api_models` in #336, so existing code doing `from tabpfn_client.constants import ModelVersion` raises `ImportError`. This re-exports it from `constants`; `api_models` stays the canonical location.

The re-export restores the enum members (now including `V3_5`), not the old class's `model_limit()` / `from_model_path()` methods. Their replacements are `tabpfn_client.utils.model_limit_from_version` and `model_version_from_path`.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165X2g14vDuGEkkxvHqRjS2