### PR TITLE
fix: stop printing from fit/predict and demote routine log records

### DIFF
--- a/changelog/385.changed.md
+++ b/changelog/385.changed.md
@@ -1,0 +1,1 @@
+`fit()` and `predict()` no longer print a progress spinner to stdout, `init()` no longer announces that it is reusing a cached token, and routine messages such as "Test set already exists, skipping upload." are logged at DEBUG instead of WARNING. `TABPFN_CLIENT_CI_MODE`, which only disabled the spinner, is removed.

--- a/src/tabpfn_client/client.py
+++ b/src/tabpfn_client/client.py
@@ -15,7 +15,6 @@ import numpy as np
 import re
 import struct
 import time
-import traceback
 import warnings
 from pydantic import BaseModel, ValidationError
 from typing import Any, cast, Mapping, NoReturn
@@ -361,7 +360,7 @@ class ServiceClient(Singleton):
         )
 
         if isinstance(prepare_resp, DuplicateTrainSetErrorResponse):
-            logger.warning("Train set already exists, skipping upload.")
+            logger.debug("Train set already exists, skipping upload.")
         else:
             with ThreadPoolExecutor(max_workers=2) as pool:
                 futures = [
@@ -708,7 +707,7 @@ class ServiceClient(Singleton):
             raise FittedModelNotFoundError(message)
 
         if isinstance(prepare_resp, DuplicateTestSetErrorResponse):
-            logger.warning("Test set already exists, skipping upload.")
+            logger.debug("Test set already exists, skipping upload.")
         else:
             cls._upload_to_gcs(
                 "x_test",
@@ -989,9 +988,8 @@ class ServiceClient(Singleton):
             if response.status_code == 200:
                 found_valid_connection = True
 
-        except httpx.ConnectError as e:
-            logger.error(f"Failed to connect to the server with error: {e}")
-            traceback.print_exc()
+        except httpx.ConnectError:
+            logger.debug("Failed to connect to the server", exc_info=True)
             found_valid_connection = False
 
         return found_valid_connection

--- a/src/tabpfn_client/config.py
+++ b/src/tabpfn_client/config.py
@@ -68,18 +68,16 @@ def init(use_server=True):
         except ConnectError:
             raise CONNECTION_ERROR
 
-        if is_valid_token:
-            PromptAgent.prompt_reusing_existing_token()
-        elif unverified_token is not None:
-            # The token is well-formed but the account's email is unverified,
-            # which no token can work around.
-            raise RuntimeError(
-                "Your TabPFN account's email address is not verified.\n"
-                "Check your inbox for the verification email, or sign in at\n"
-                f"  {ServiceClient.server_config.gui_url}\n"
-                "to request a new one, then run your script again."
-            )
-        else:
+        if not is_valid_token:
+            if unverified_token is not None:
+                # The token is well-formed but the account's email is unverified,
+                # which no token can work around.
+                raise RuntimeError(
+                    "Your TabPFN account's email address is not verified.\n"
+                    "Check your inbox for the verification email, or sign in at\n"
+                    f"  {ServiceClient.server_config.gui_url}\n"
+                    "to request a new one, then run your script again."
+                )
             if not UserAuthenticationClient.is_accessible_connection():
                 raise CONNECTION_ERROR
             # Never prompt from the default path: this is a library, so a

--- a/src/tabpfn_client/estimator.py
+++ b/src/tabpfn_client/estimator.py
@@ -4,13 +4,10 @@
 from __future__ import annotations
 
 import logging
-import sys
-import time
+import warnings
 from uuid import uuid4
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Literal, cast, overload
+from typing import Any, Literal, cast, overload
 from typing_extensions import Self
-from uuid import UUID
 
 import numpy as np
 import pandas as pd
@@ -45,7 +42,6 @@ from tabpfn_client.api_models import (
 )
 from tabpfn_client.models import ApiMode, TabPFNConfig, FitModeLiteral
 from tabpfn_client.persistence import ModelPersistenceMixin
-from tabpfn_client.options import get_opts
 
 try:
     from torch import Tensor  # type: ignore
@@ -329,19 +325,16 @@ class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelect
 
             self._last_trace_id = self.client_options.headers["sentry-trace"]
 
-            def fit_task() -> UUID:
-                return InferenceClient.fit(
-                    X_clean,
-                    y,
-                    task_config=task_config,
-                    tabpfn_systems=tabpfn_systems,
-                    thinking_config=thinking_config,
-                    api_mode=self.api_mode,
-                    client_options=self.client_options,
-                    description=description,
-                )
-
-            self.model_id_ = cast(UUID, run_task(fit_task, "Fitting"))
+            self.model_id_ = InferenceClient.fit(
+                X_clean,
+                y,
+                task_config=task_config,
+                tabpfn_systems=tabpfn_systems,
+                thinking_config=thinking_config,
+                api_mode=self.api_mode,
+                client_options=self.client_options,
+                description=description,
+            )
             # NOTE: Previously classes were assigned in-place before a fit succeeded,
             # consider this failure mode:
             #  1. first fit() -> succeeds, model_id_ and classes_ are assigned
@@ -414,19 +407,16 @@ class TabPFNClassifier(ClassifierMixin, ModelPersistenceMixin, TabPFNModelSelect
         ):
             self.client_options.headers["sentry-trace"] = self._last_trace_id
 
-        def predict_task() -> PredictionResult:
-            return InferenceClient.predict(
-                X_clean,
-                fitted_train_set_id=self.model_id_,
-                task_config=task_config,
-                client_options=self.client_options,
-            )
-
-        result = run_task(predict_task, "Predicting")
+        result = InferenceClient.predict(
+            X_clean,
+            fitted_train_set_id=self.model_id_,
+            task_config=task_config,
+            client_options=self.client_options,
+        )
         # Unpack and store metadata
         self._last_meta = result.metadata
 
-        return result.y_pred
+        return cast("np.ndarray", result.y_pred)
 
     def _get_tabpfn_config(self) -> ClassifierTabPFNConfig:
         init_params = self.get_params()
@@ -674,19 +664,16 @@ class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelectio
 
             self._last_trace_id = self.client_options.headers["sentry-trace"]
 
-            def fit_task() -> UUID:
-                return InferenceClient.fit(
-                    X_clean,
-                    y,
-                    task_config=task_config,
-                    tabpfn_systems=tabpfn_systems,
-                    thinking_config=thinking_config,
-                    api_mode=self.api_mode,
-                    client_options=self.client_options,
-                    description=description,
-                )
-
-            self.model_id_ = cast(UUID, run_task(fit_task, "Fitting"))
+            self.model_id_ = InferenceClient.fit(
+                X_clean,
+                y,
+                task_config=task_config,
+                tabpfn_systems=tabpfn_systems,
+                thinking_config=thinking_config,
+                api_mode=self.api_mode,
+                client_options=self.client_options,
+                description=description,
+            )
             self._n_train_rows = X.shape[0]
             self._fit_count += 1
         else:
@@ -775,17 +762,12 @@ class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelectio
             self.client_options.headers["sentry-trace"] = self._last_trace_id
 
         def predict_rows(X_rows: Any) -> PredictionResult:
-            X_clean = _clean_text_features(X_rows)
-
-            def predict_task() -> PredictionResult:
-                return InferenceClient.predict(
-                    X_clean,
-                    fitted_train_set_id=self.model_id_,
-                    task_config=task_config,
-                    client_options=self.client_options,
-                )
-
-            return run_task(predict_task, "Predicting")
+            return InferenceClient.predict(
+                _clean_text_features(X_rows),
+                fitted_train_set_id=self.model_id_,
+                task_config=task_config,
+                client_options=self.client_options,
+            )
 
         if chunked:
             rows_per_call = cast(int, rows_per_call)
@@ -821,9 +803,10 @@ class TabPFNRegressor(RegressorMixin, ModelPersistenceMixin, TabPFNModelSelectio
                     borders=torch.tensor(full["borders"])
                 )
             except ImportError:
-                logger.warning(
+                warnings.warn(
                     "Optional dependencies 'tabpfn' and 'torch' are required to "
-                    "construct the criterion when output_type='full'. Skipping criterion."
+                    "construct the criterion when output_type='full'. Skipping criterion.",
+                    stacklevel=2,
                 )
             return full
 
@@ -1048,34 +1031,6 @@ def _clean_text_features(X):
     if isinstance(data, np.ndarray):
         return df.to_numpy()
     return df
-
-
-def run_task(task: Callable, message: str, with_spinner: bool = True) -> Any:
-    if not with_spinner or get_opts().TABPFN_CLIENT_CI_MODE:
-        result = task()
-    else:
-        start = time.time()
-        spinner = ["-", "\\", "|", "/"]
-        i = 0
-        minutes = 0
-        seconds = 0
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(task)
-            while not future.done():
-                elapsed = int(time.time() - start)
-                minutes = elapsed // 60
-                seconds = elapsed % 60
-                sys.stdout.write(
-                    f"\r{minutes:02d}:{seconds:02d} {message}... {spinner[i % len(spinner)]}"
-                )
-                sys.stdout.flush()
-                time.sleep(0.2)
-                i += 1
-            result = future.result()
-        # Remove spinner, but keep elapsed time
-        sys.stdout.write(f"\r{minutes:02d}:{seconds:02d} {message}... Done!\n")
-        sys.stdout.flush()
-    return result
 
 
 def _build_fit_task_config(tabpfn_config: TabPFNConfig) -> FitTaskConfig:

--- a/src/tabpfn_client/options.py
+++ b/src/tabpfn_client/options.py
@@ -10,7 +10,6 @@ class Options(BaseSettings):
     TABPFN_CLIENT_MAX_THREAD_PER_UPLOAD: int = 8
     TABPFN_CLIENT_TIMEOUT: float = 900.0
     TABPFN_CLIENT_UPLOAD_TIMEOUT: float = 7200.0  # 2 hours
-    TABPFN_CLIENT_CI_MODE: bool = False
     TABPFN_CLIENT_FORCE_REUPLOAD: bool = False
     TABPFN_CLIENT_DEDUP_DATASETS: bool = True
 

--- a/src/tabpfn_client/prompt_agent.py
+++ b/src/tabpfn_client/prompt_agent.py
@@ -355,10 +355,6 @@ class PromptAgent:
             )
 
     @classmethod
-    def prompt_reusing_existing_token(cls):
-        notify("Found existing access token, reusing it for authentication.")
-
-    @classmethod
     def prompt_retrieved_greeting_messages(cls, greeting_messages: list[str]):
         for message in greeting_messages:
             notify(cls.indent(message))

--- a/src/tabpfn_client/service_wrapper.py
+++ b/src/tabpfn_client/service_wrapper.py
@@ -211,50 +211,27 @@ class UserDataClient(ServiceClientWrapper, Singleton):
 
     @classmethod
     def get_data_summary(cls) -> dict:
-        try:
-            summary = ServiceClient.get_data_summary()
-        except RuntimeError as e:
-            logging.error(f"Failed to get data summary: {e}")
-            raise e
-
-        return summary
+        return ServiceClient.get_data_summary()
 
     @classmethod
     def download_all_data(cls, save_dir: Path = Path(".")) -> Path:
-        try:
-            saved_path = ServiceClient.download_all_data(save_dir)
-        except RuntimeError as e:
-            logging.error(f"Failed to download data: {e}")
-            raise e
-
+        saved_path = ServiceClient.download_all_data(save_dir)
         if saved_path is None:
             raise RuntimeError("Failed to download data.")
 
-        logging.info(f"Data saved to {saved_path}")
+        logger.info(f"Data saved to {saved_path}")
         return saved_path
 
     @classmethod
     def delete_dataset(cls, dataset_uid: str) -> list[str]:
-        try:
-            deleted_datasets = ServiceClient.delete_dataset(dataset_uid)
-        except RuntimeError as e:
-            logging.error(f"Failed to delete dataset: {e}")
-            raise e
-
-        logging.info(f"Deleted datasets: {deleted_datasets}")
-
+        deleted_datasets = ServiceClient.delete_dataset(dataset_uid)
+        logger.info(f"Deleted datasets: {deleted_datasets}")
         return deleted_datasets
 
     @classmethod
     def delete_all_datasets(cls) -> list[str]:
-        try:
-            deleted_datasets = ServiceClient.delete_all_datasets()
-        except RuntimeError as e:
-            logging.error(f"Failed to delete all datasets: {e}")
-            raise e
-
-        logging.info(f"Deleted datasets: {deleted_datasets}")
-
+        deleted_datasets = ServiceClient.delete_all_datasets()
+        logger.info(f"Deleted datasets: {deleted_datasets}")
         return deleted_datasets
 
     @classmethod
@@ -266,12 +243,7 @@ class UserDataClient(ServiceClientWrapper, Singleton):
             logger.info("Account deletion cancelled — confirmation phrase not entered.")
             return
 
-        try:
-            ServiceClient.delete_user_account()
-        except RuntimeError as e:
-            logging.error(f"Failed to delete user account: {e}")
-            raise e
-
+        ServiceClient.delete_user_account()
         PromptAgent.prompt_account_deleted()
 
 

--- a/src/tabpfn_client/ui.py
+++ b/src/tabpfn_client/ui.py
@@ -9,14 +9,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from rich.console import Console
-from rich.panel import Panel
-from rich.progress import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
 
 
 def _should_use_color() -> bool:
@@ -30,17 +22,6 @@ def _should_use_color() -> bool:
 
 
 console = Console(soft_wrap=False, highlight=True, force_terminal=_should_use_color())
-
-
-def header(title: str, subtitle: str | None = None) -> None:
-    """Render a section header."""
-
-    console.print(
-        Panel.fit(
-            title if not subtitle else f"[bold]{title}[/bold]\n[dim]{subtitle}[/dim]"
-        )
-    )
-
 
 logger = logging.getLogger(__name__)
 
@@ -69,26 +50,10 @@ def fail(message: str) -> None:
     console.print(f"[bold red]{message}[/bold red]")
 
 
-def info(message: str) -> None:
-    console.print(f"[blue]{message}[/blue]")
-
-
 @contextmanager
 def status(message: str) -> Generator[None]:
     with console.status(f"[bold]{message}[/bold]"):
         yield
-
-
-def progress_bar(description: str = "Working...") -> Progress:
-    return Progress(
-        SpinnerColumn(),
-        TextColumn("[bold]{task.description}"),
-        BarColumn(),
-        TextColumn("{task.completed}/{task.total}"),
-        TimeElapsedColumn(),
-        console=console,
-        transient=True,
-    )
 
 
 # =============================
@@ -103,10 +68,6 @@ _PRIOR_LABS_ASCII = r"""
 ###       ###   ##   ###  #########  ###   ###       ########   ###  ###   ########  ########                                                     
 """
 
-_PRIOR_LABS_ASCII_SMALL = r"""
-[ PRIOR LABS ]
-"""
-
 
 def print_logo(subtitle=None) -> None:
     """Print the large Prior Labs ASCII logo with optional subtitle."""
@@ -115,22 +76,12 @@ def print_logo(subtitle=None) -> None:
         console.print(f"[dim]{subtitle}[/dim]", end="\n\n")
 
 
-def print_logo_small(subtitle=None) -> None:
-    """Print a small Prior Labs ASCII banner with optional subtitle."""
-    console.print(_PRIOR_LABS_ASCII_SMALL, style="bold blue")
-    if subtitle:
-        console.print(f"[dim]{subtitle}[/dim]")
-
-
 __all__ = [
     "console",
     "fail",
-    "header",
+    "notify",
     "print_logo",
-    "print_logo_small",
-    "progress_bar",
     "status",
     "success",
-    "info",
     "warn",
 ]

--- a/src/tabpfn_client/ui.py
+++ b/src/tabpfn_client/ui.py
@@ -9,7 +9,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from rich.console import Console
-from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
@@ -31,24 +30,6 @@ def _should_use_color() -> bool:
 
 
 console = Console(soft_wrap=False, highlight=True, force_terminal=_should_use_color())
-
-
-def setup_logging(verbosity: int = 0) -> None:
-    """Configure logging to emit through Rich with a consistent style."""
-
-    level = logging.WARNING - min(verbosity, 2) * 10
-    logging.basicConfig(
-        level=level,
-        format="%(message)s",
-        handlers=[
-            RichHandler(
-                console=console,
-                rich_tracebacks=True,
-                show_time=False,
-                show_path=False,
-            )
-        ],
-    )
 
 
 def header(title: str, subtitle: str | None = None) -> None:
@@ -148,7 +129,6 @@ __all__ = [
     "print_logo",
     "print_logo_small",
     "progress_bar",
-    "setup_logging",
     "status",
     "success",
     "info",

--- a/tests/unit/test_tabpfn_regressor.py
+++ b/tests/unit/test_tabpfn_regressor.py
@@ -604,7 +604,7 @@ class TestTabPFNRegressorInference(unittest.TestCase):
         self.assertIsInstance(output["criterion"], DummyFullSupportBarDistribution)
         self.assertEqual(output["criterion"].borders, dummy_output["borders"])
 
-    def test_predict_full_missing_optional_dependencies_logs_warning(self):
+    def test_predict_full_missing_optional_dependencies_warns(self):
         regressor = TabPFNRegressor()
         regressor.model_id_ = UUID("00000000-0000-0000-0000-000000000000")
         regressor._n_train_rows = 5
@@ -625,15 +625,10 @@ class TestTabPFNRegressorInference(unittest.TestCase):
                 return original_import(name, *args, **kwargs)
 
             with patch("builtins.__import__", side_effect=import_side_effect):
-                with self.assertLogs(
-                    "tabpfn_client.estimator", level="WARNING"
-                ) as captured_logs:
+                with self.assertWarnsRegex(UserWarning, "Optional dependencies"):
                     output = regressor.predict(test_X, output_type="full")
 
         self.assertNotIn("criterion", output)
-        self.assertTrue(
-            any("Optional dependencies" in message for message in captured_logs.output)
-        )
 
     def test_predict_with_long_and_comma_text(self):
         """Test predictions with long text (>2500 chars) and text containing commas."""


### PR DESCRIPTION
`fit()` and `predict()` wrote a `\r` spinner to stdout on every call, and routine events were logged at WARNING, which Python prints to stderr even when the application has configured no logging. In scripts and CI logs the spinner frames end up in captured output; in notebooks the spinner and log lines share one output line. A library should leave stdout and logging configuration to the application.

- **Spinner removed.** `fit()` and `predict()` call the server directly, without the worker thread the spinner needed. `TABPFN_CLIENT_CI_MODE`, which only disabled the spinner, is removed; setting it is now a no-op.
- **"Train/Test set already exists, skipping upload."** is logged at DEBUG. It is the normal dedup path, e.g. predicting on the same `X` twice.
- **`init()` no longer prints "Found existing access token, reusing it for authentication."** on every run in a terminal. `try_reuse_existing_token()` already logs the same event at DEBUG.
- **`try_connection()`** no longer logs an ERROR and calls `traceback.print_exc()` before `init()` raises its own connection error. The traceback is logged at DEBUG.
- **`UserDataClient`** logs through its module logger. It called `logging.info()` / `logging.error()`, which run `basicConfig()` when the root logger has no handlers, so a later `basicConfig()` in the application did nothing. The error logs that preceded a re-raise are dropped.
- **Missing `tabpfn` / `torch` for `output_type="full"`** is now a `UserWarning` via `warnings.warn`: the caller can act on it and filter it.
- **Unused `ui` helpers** are removed: `setup_logging()` (a `basicConfig()` helper), `header()`, `info()`, `progress_bar()` and `print_logo_small()`. None had callers.

Unchanged: the interactive login and signup flows still print, since they are opt-in and need a terminal, and server greeting messages still go through `notify()`.

Not in this PR: the import-time `setLevel(WARNING)` on the `httpx` / `httpcore` loggers, and the server deprecation notice being a `DeprecationWarning`, which is hidden by default outside `__main__`.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bhEkFCJWSiwyStDihRFMa
